### PR TITLE
[feat] 회원의 주소 조회 #1

### DIFF
--- a/src/main/java/com/back/domain/member/address/controller/AddressController.java
+++ b/src/main/java/com/back/domain/member/address/controller/AddressController.java
@@ -11,10 +11,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/addresses")
@@ -53,6 +52,35 @@ public class AddressController {
                         address.getContent(),
                         new MemberDto(address.getMember())
                 )
+        );
+    }
+
+    record AddressListResBody(
+            Long id,
+            String content,
+            boolean isDefault
+    ) {
+    }
+
+    @GetMapping
+    @Operation(summary = "주소 목록 조회")
+    public RsData<AddressListResBody[]> getAddressList() {
+        Member member = rq.getActor();
+
+        List<Address> addresses = addressService.getAddressList(member);
+
+        AddressListResBody[] resBodies = addresses.stream()
+                .map(address -> new AddressListResBody(
+                        address.getId(),
+                        address.getContent(),
+                        address.getIsDefault()
+                ))
+                .toArray(AddressListResBody[]::new);
+
+        return new RsData<>(
+                200,
+                "주소 목록을 조회했습니다.",
+                resBodies
         );
     }
 

--- a/src/main/java/com/back/domain/member/address/service/AddressService.java
+++ b/src/main/java/com/back/domain/member/address/service/AddressService.java
@@ -8,6 +8,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class AddressService {
@@ -23,5 +25,10 @@ public class AddressService {
         Address address = new Address(content, false, member);
 
         return addressRepository.save(address);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Address> getAddressList(Member member) {
+        return addressRepository.findAllByMember(member);
     }
 }

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -119,4 +119,10 @@ public class Member {
         return Optional.of(addresses.get(addresses.size() - 1));
     }
 
+    public Optional<Address> getDefaultAddress() {
+        return addresses.stream()
+                .filter(Address::getIsDefault)
+                .findFirst();
+    }
+
 }

--- a/src/test/java/com/back/domain/member/address/controller/AddressControllerTest.java
+++ b/src/test/java/com/back/domain/member/address/controller/AddressControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -125,4 +126,83 @@ class AddressControllerTest {
                 .andExpect(jsonPath("$.code").value(400))
                 .andExpect(jsonPath("$.message").value("content-NotBlank-must not be blank"));
     }
+
+    @Test
+    @DisplayName("전체 주소 조회")
+    @WithUserDetails("user1@gmail.com")
+    void getAddresses() throws Exception {
+        // Given: 유저가 존재하고, 여러 주소가 등록되어 있음
+        Member member = memberService.findByEmail("user1@gmail.com")
+                .orElseThrow(() -> new IllegalStateException("유저가 존재하지 않습니다."));
+
+        addressService.submitAddress(member, "서울특별시");
+        addressService.submitAddress(member, "부산광역시");
+        addressService.submitAddress(member, "대구광역시");
+
+        // When: 주소 목록을 조회하는 API를 호출
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/addresses")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        // Then: 주소 목록이 올바르게 반환되고, 상태 코드가 200이어야 함
+        resultActions
+                .andExpect(handler().handlerType(AddressController.class))
+                .andExpect(handler().methodName("getAddresses"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("주소 목록을 조회했습니다."))
+                .andExpect(jsonPath("$.data.length()").value(3))
+                .andExpect(jsonPath("$.data[0].content").value("서울특별시"))
+                .andExpect(jsonPath("$.data[1].content").value("부산광역시"))
+                .andExpect(jsonPath("$.data[2].content").value("대구광역시"));
+    }
+
+    @Test
+    @DisplayName("전체 주소 조회 - 주소 목록이 비어있음")
+    @WithUserDetails("user1@gmail.com")
+    void getAddresses_emptyAddress() throws Exception {
+        // Given: 유저가 존재하고, 여러 주소가 등록되어 있음
+        Member member = memberService.findByEmail("user1@gmail.com")
+                .orElseThrow(() -> new IllegalStateException("유저가 존재하지 않습니다."));
+
+        // When: 주소 목록을 조회하는 API를 호출
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/addresses")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        // Then: 빈 주소 목록이 올바르게 반환되고, 상태 코드가 200이어야 함
+        resultActions
+                .andExpect(handler().handlerType(AddressController.class))
+                .andExpect(handler().methodName("getAddresses"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("주소 목록을 조회했습니다."))
+                .andExpect(jsonPath("$.data.length()").value(0));
+    }
+
+    @Test
+    @DisplayName("전체 주소 조회 - 인증된 유저가 없음")
+    void getAddresses_withoutAuth() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/addresses")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(AddressController.class))
+                .andExpect(handler().methodName("getAddresses"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(401))
+                .andExpect(jsonPath("$.message").value("로그인 후 이용해주세요."));
+    }
+
+
 }

--- a/src/test/java/com/back/domain/member/address/controller/AddressControllerTest.java
+++ b/src/test/java/com/back/domain/member/address/controller/AddressControllerTest.java
@@ -130,7 +130,7 @@ class AddressControllerTest {
     @Test
     @DisplayName("전체 주소 조회")
     @WithUserDetails("user1@gmail.com")
-    void getAddresses() throws Exception {
+    void getAddressList() throws Exception {
         // Given: 유저가 존재하고, 여러 주소가 등록되어 있음
         Member member = memberService.findByEmail("user1@gmail.com")
                 .orElseThrow(() -> new IllegalStateException("유저가 존재하지 않습니다."));
@@ -150,7 +150,7 @@ class AddressControllerTest {
         // Then: 주소 목록이 올바르게 반환되고, 상태 코드가 200이어야 함
         resultActions
                 .andExpect(handler().handlerType(AddressController.class))
-                .andExpect(handler().methodName("getAddresses"))
+                .andExpect(handler().methodName("getAddressList"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("주소 목록을 조회했습니다."))
@@ -163,7 +163,7 @@ class AddressControllerTest {
     @Test
     @DisplayName("전체 주소 조회 - 주소 목록이 비어있음")
     @WithUserDetails("user1@gmail.com")
-    void getAddresses_emptyAddress() throws Exception {
+    void getAddressList_emptyList() throws Exception {
         // Given: 유저가 존재하고, 여러 주소가 등록되어 있음
         Member member = memberService.findByEmail("user1@gmail.com")
                 .orElseThrow(() -> new IllegalStateException("유저가 존재하지 않습니다."));
@@ -179,7 +179,7 @@ class AddressControllerTest {
         // Then: 빈 주소 목록이 올바르게 반환되고, 상태 코드가 200이어야 함
         resultActions
                 .andExpect(handler().handlerType(AddressController.class))
-                .andExpect(handler().methodName("getAddresses"))
+                .andExpect(handler().methodName("getAddressList"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("주소 목록을 조회했습니다."))
@@ -188,7 +188,7 @@ class AddressControllerTest {
 
     @Test
     @DisplayName("전체 주소 조회 - 인증된 유저가 없음")
-    void getAddresses_withoutAuth() throws Exception {
+    void getAddressList_withoutAuth() throws Exception {
         ResultActions resultActions = mvc
                 .perform(
                         get("/api/addresses")
@@ -197,8 +197,6 @@ class AddressControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(AddressController.class))
-                .andExpect(handler().methodName("getAddresses"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(401))
                 .andExpect(jsonPath("$.message").value("로그인 후 이용해주세요."));


### PR DESCRIPTION
## 📢 기능 설명
- Member Entity에 default 주소 반환 메서드 추가
- 현재 로그인한 멤버의 주소를 모두 반환하는 엔드 포인트 추가
<br>

## 연결된 issue
close #22
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 현재 로그인된 회원의 주소 목록을 조회할 수 있는 API가 추가되었습니다.

* **버그 수정**
  * 주소 목록 조회 시 인증되지 않은 사용자는 접근이 제한됩니다.

* **테스트**
  * 주소 목록 조회 API의 정상 동작, 빈 목록 반환, 인증 실패 케이스에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->