### PR TITLE
[feat] 주소 Entity 삭제 기능 #1

### DIFF
--- a/src/main/java/com/back/domain/member/address/controller/AddressController.java
+++ b/src/main/java/com/back/domain/member/address/controller/AddressController.java
@@ -84,6 +84,21 @@ public class AddressController {
         );
     }
 
+    @DeleteMapping("/{addressId}")
+    @Operation(summary = "주소 삭제")
+    public RsData<Void> deleteAddress(
+            @PathVariable Long addressId
+    ) {
+        Member member = rq.getActor();
+        addressService.deleteAddress(member, addressId);
+
+        return new RsData<>(
+                204,
+                "주소가 삭제됐습니다.",
+                null
+        );
+    }
+
 
 
 }

--- a/src/main/java/com/back/domain/member/address/service/AddressService.java
+++ b/src/main/java/com/back/domain/member/address/service/AddressService.java
@@ -31,4 +31,15 @@ public class AddressService {
     public List<Address> getAddressList(Member member) {
         return addressRepository.findAllByMember(member);
     }
+
+    @Transactional
+    public void deleteAddress(Member member, Long addressId) {
+        Address address = addressRepository.findById(addressId)
+                .orElseThrow(() -> new ServiceException(404, "주소를 찾을 수 없습니다."));
+
+        if (!address.getMember().equals(member))
+            throw new ServiceException(403, "다른 유저의 주소는 삭제할 수 없습니다.");
+
+        addressRepository.delete(address);
+    }
 }

--- a/src/test/java/com/back/domain/member/address/controller/AddressControllerTest.java
+++ b/src/test/java/com/back/domain/member/address/controller/AddressControllerTest.java
@@ -223,8 +223,8 @@ class AddressControllerTest {
         resultActions
                 .andExpect(handler().handlerType(AddressController.class))
                 .andExpect(handler().methodName("deleteAddress"))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(status().isNoContent())
+                .andExpect(jsonPath("$.code").value(204))
                 .andExpect(jsonPath("$.message").value("주소가 삭제됐습니다."));
     }
 


### PR DESCRIPTION
## 📢 기능 설명
- 주소 삭제 기능 엔드포인트 추가
- 정상 경우, 인가 없는 경우, 주소가 없는 경우에 대한 테스트 작성
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #24 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 주소 삭제를 위한 엔드포인트가 추가되었습니다. 사용자는 자신의 주소를 삭제할 수 있습니다.

* **버그 수정**
  * 다른 사용자의 주소 삭제 시 403 오류가 반환됩니다.
  * 존재하지 않는 주소 삭제 시 404 오류가 반환됩니다.

* **테스트**
  * 주소 삭제 기능에 대한 정상 동작, 권한 오류, 존재하지 않는 주소 오류 케이스가 테스트에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->