### PR TITLE
[feat] 멤버 삭제(회원 탈퇴) 구현#1

### DIFF
--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -14,12 +14,14 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/members")
 @RequiredArgsConstructor
+@Slf4j
 @Tag(name = "MemberController", description = "회원 관리 엔드포인트")
 public class MemberController {
     private final MemberService memberService;
@@ -114,6 +116,26 @@ public class MemberController {
         return new RsData<>(
                 200,
                 "로그아웃 됐습니다.",
+                null
+        );
+    }
+
+    @DeleteMapping("/withdraw")
+    @Operation(summary = "회원 탈퇴")
+    @Transactional
+    public RsData<Void> withdraw() {
+        Member member = rq.getActor();
+
+        log.debug("탈퇴 요청한 회원: {}", member.isAdmin());
+
+        memberService.withdraw(member);
+
+        rq.deleteCookie("apiKey");
+        rq.deleteCookie("accessToken");
+
+        return new RsData<>(
+                200,
+                "회원 탈퇴가 완료되었습니다.",
                 null
         );
     }

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -81,6 +81,18 @@ public class Member {
         this.name = name;
     }
 
+    public Member(Long id, String email, String name, boolean isAdmin) {
+        if (email == null || email.trim().isEmpty())
+            throw new IllegalArgumentException("이메일은 비어있을 수 없습니다.");
+        if (name == null || name.trim().isEmpty())
+            throw new IllegalArgumentException("이름은 비어있을 수 없습니다.");
+
+        this.id = (long) id;
+        this.email = email;
+        this.name = name;
+        this.isAdmin = isAdmin;
+    }
+
     // ------------ [메서드] ------------
     public boolean isAdmin() {
         return isAdmin;

--- a/src/main/java/com/back/domain/member/member/service/AuthTokenService.java
+++ b/src/main/java/com/back/domain/member/member/service/AuthTokenService.java
@@ -19,11 +19,12 @@ public class AuthTokenService {
         long id = member.getId();
         String email = member.getEmail();
         String name = member.getName();
+        boolean isAdmin = member.isAdmin();
 
         return Ut.jwt.toString(
                 jwtSecretKey,
                 accessTokenExpirationSeconds,
-                Map.of("id", id, "email", email, "name", name)
+                Map.of("id", id, "email", email, "name", name, "isAdmin", isAdmin)
         );
     }
 

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -70,4 +70,11 @@ public class MemberService {
 
     }
 
+    public void withdraw(Member member) {
+        if (member.isAdmin())
+            throw new ServiceException(403, "관리자는 탈퇴할 수 없습니다.");
+
+
+        memberRepository.delete(member);
+    }
 }

--- a/src/main/java/com/back/global/initData/DevInitData.java
+++ b/src/main/java/com/back/global/initData/DevInitData.java
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class DevInitData {
     @Autowired
     @Lazy
-    private TestInitData self;
+    private DevInitData self;
     private final MemberService memberService;
 
     @Bean

--- a/src/main/java/com/back/global/initData/DevInitData.java
+++ b/src/main/java/com/back/global/initData/DevInitData.java
@@ -20,11 +20,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class DevInitData {
     @Autowired
     @Lazy
-    private DevInitData self;
+    private TestInitData self;
     private final MemberService memberService;
 
     @Bean
-    ApplicationRunner baseInitDataApplicationRunner() {
+    ApplicationRunner devInitDataApplicationRunner() {
         return args -> {
             self.work1();
         };

--- a/src/main/java/com/back/global/initData/TestInitData.java
+++ b/src/main/java/com/back/global/initData/TestInitData.java
@@ -24,7 +24,7 @@ public class TestInitData {
     private final MemberService memberService;
 
     @Bean
-    ApplicationRunner baseInitDataApplicationRunner() {
+    ApplicationRunner testInitDataApplicationRunner() {
         return args -> {
             self.work1();
         };

--- a/src/main/java/com/back/global/rq/Rq.java
+++ b/src/main/java/com/back/global/rq/Rq.java
@@ -29,7 +29,7 @@ public class Rq {
                 .map(Authentication::getPrincipal)
                 .filter(principal -> principal instanceof SecurityUser)
                 .map(principal -> (SecurityUser) principal)
-                .map(securityUser -> new Member(securityUser.getId(), securityUser.getEmail(), securityUser.getUsername()))
+                .map(securityUser -> new Member(securityUser.getId(), securityUser.getEmail(), securityUser.getUsername(), securityUser.isAdmin()))
                 .orElse(null);
     }
 

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -100,7 +100,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                 Long id = (Long) payload.get("id");
                 String email = (String) payload.get("email");
                 String name = (String) payload.get("name");
-                boolean isAdmin = (Boolean) payload.get("isAdmin");
+                boolean isAdmin = Boolean.TRUE.equals(payload.get("isAdmin"));
                 member = new Member(id, email, name, isAdmin);
 
                 isAccessTokenValid = true;

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -100,7 +100,8 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                 Long id = (Long) payload.get("id");
                 String email = (String) payload.get("email");
                 String name = (String) payload.get("name");
-                member = new Member(id, email, name);
+                boolean isAdmin = (Boolean) payload.get("isAdmin");
+                member = new Member(id, email, name, isAdmin);
 
                 isAccessTokenValid = true;
             }
@@ -125,6 +126,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
                 member.getEmail(),
                 member.getName(),
                 member.getPassword(),
+                member.isAdmin(),
                 member.getAuthorities()
         );
 

--- a/src/main/java/com/back/global/security/CustomUserDetailsService.java
+++ b/src/main/java/com/back/global/security/CustomUserDetailsService.java
@@ -23,6 +23,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                 member.getEmail(),
                 member.getName(),
                 "N/A",
+                member.isAdmin(),
                 member.getAuthorities()
         );
     }

--- a/src/main/java/com/back/global/security/SecurityUser.java
+++ b/src/main/java/com/back/global/security/SecurityUser.java
@@ -11,16 +11,20 @@ public class SecurityUser extends User {
     private final Long id;
     @Getter
     private final String email;
+    @Getter
+    private final boolean isAdmin;
 
     public SecurityUser(
             Long id,
             String email,
             String name,
             String password,
+            boolean isAdmin,
             Collection<? extends GrantedAuthority> authorities
     ) {
         super(name, password, authorities);
         this.id = id;
         this.email = email;
+        this.isAdmin = isAdmin;
     }
 }

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -235,7 +235,7 @@ class MemberControllerTest {
     void withdraw_notLoggedIn() throws Exception {
         ResultActions resultActions = mvc
                 .perform(
-                        delete("/api/members/me")
+                        delete("/api/members/withdraw")
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -190,17 +190,17 @@ class MemberControllerTest {
     @Test
     @DisplayName("회원 탈퇴")
     @WithUserDetails("user1@gmail.com")
-    void deleteAccount() throws Exception {
+    void withdraw() throws Exception {
         ResultActions resultActions = mvc
                 .perform(
-                        delete("/api/members/me")
+                        delete("/api/members/withdraw")
                                 .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 
         resultActions
                 .andExpect(handler().handlerType(MemberController.class))
-                .andExpect(handler().methodName("deleteAccount"))
+                .andExpect(handler().methodName("withdraw"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("회원 탈퇴가 완료되었습니다."));
@@ -211,8 +211,28 @@ class MemberControllerTest {
     }
 
     @Test
+    @DisplayName("회원 탈퇴 - 어드민 계정으로 시도")
+    @WithUserDetails("system@gmail.com")
+    void withdraw_admin() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        delete("/api/members/withdraw")
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("withdraw"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(403))
+                .andExpect(jsonPath("$.message").value("관리자는 탈퇴할 수 없습니다."));
+
+    }
+
+    @Test
     @DisplayName("회원 탈퇴 - 로그인하지 않은 경우")
-    void deleteAccount_notLoggedIn() throws Exception {
+    void withdraw_notLoggedIn() throws Exception {
         ResultActions resultActions = mvc
                 .perform(
                         delete("/api/members/me")
@@ -221,8 +241,6 @@ class MemberControllerTest {
                 .andDo(print());
 
         resultActions
-                .andExpect(handler().handlerType(MemberController.class))
-                .andExpect(handler().methodName("deleteAccount"))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.code").value(401))
                 .andExpect(jsonPath("$.message").value("로그인 후 이용해주세요."));


### PR DESCRIPTION
## 📢 기능 설명
- 회원 탈퇴 구현
- 관련 테스트 케이스 구현
- jwt 에서 admin 여부도 함께 반환하도록 변경
<br>

## 연결된 issue
close #17
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * 회원 탈퇴(계정 삭제) 기능이 추가되었습니다. 일반 사용자는 계정 탈퇴가 가능하며, 탈퇴 시 인증 쿠키가 삭제됩니다.
  * JWT 토큰에 관리자 여부 정보가 포함되어 사용자 권한 관리가 강화되었습니다.
* **버그 수정**
  * 관리자 계정은 탈퇴를 시도할 경우 제한되며, 적절한 안내 메시지가 제공됩니다.
* **테스트**
  * 회원 탈퇴, 관리자 탈퇴 제한, 비로그인 시 탈퇴 요청에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->