### PR TITLE
[feat] 회원 정보 조회 #1

### DIFF
--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -126,8 +126,6 @@ public class MemberController {
     public RsData<Void> withdraw() {
         Member member = rq.getActor();
 
-        log.debug("탈퇴 요청한 회원: {}", member.isAdmin());
-
         memberService.withdraw(member);
 
         rq.deleteCookie("apiKey");
@@ -137,6 +135,22 @@ public class MemberController {
                 200,
                 "회원 탈퇴가 완료되었습니다.",
                 null
+        );
+    }
+
+    @GetMapping("/info")
+    @Operation(summary = "회원 정보 조회")
+    @Transactional(readOnly = true)
+    public RsData<MemberWithAuthDto> getMemberInfo() {
+        Member actor = rq.getActor();
+
+        Member member = memberService.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException(404, "존재하지 않는 회원입니다."));
+
+        return new RsData<>(
+                200,
+                "회원 정보가 조회됐습니다.",
+                new MemberWithAuthDto(member)
         );
     }
 

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -124,7 +124,9 @@ public class MemberController {
     @Operation(summary = "회원 탈퇴")
     @Transactional
     public RsData<Void> withdraw() {
-        Member member = rq.getActor();
+        Member actor = rq.getActor();
+        Member member = memberService.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException(404, "존재하지 않는 회원입니다."));
 
         memberService.withdraw(member);
 

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package com.back.domain.member.member.controller;
 
 import com.back.domain.member.member.dto.MemberDto;
+import com.back.domain.member.member.dto.MemberUpdateDto;
 import com.back.domain.member.member.dto.MemberWithAuthDto;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
@@ -145,13 +146,33 @@ public class MemberController {
     @Transactional(readOnly = true)
     public RsData<MemberWithAuthDto> getMemberInfo() {
         Member actor = rq.getActor();
-
         Member member = memberService.findById(actor.getId())
                 .orElseThrow(() -> new ServiceException(404, "존재하지 않는 회원입니다."));
 
         return new RsData<>(
                 200,
                 "회원 정보가 조회됐습니다.",
+                new MemberWithAuthDto(member)
+        );
+    }
+
+
+
+
+    @PutMapping("/info")
+    @Operation(summary = "회원 정보 수정")
+    public RsData<MemberWithAuthDto> updateMemberInfo(
+            @Valid @RequestBody MemberUpdateDto reqBody
+    ) {
+        Member actor = rq.getActor();
+        Member member = memberService.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException(404, "존재하지 않는 회원입니다."));
+
+        memberService.modify(reqBody, member);
+
+        return new RsData<>(
+                200,
+                "회원 정보가 수정됐습니다.",
                 new MemberWithAuthDto(member)
         );
     }

--- a/src/main/java/com/back/domain/member/member/dto/MemberUpdateDto.java
+++ b/src/main/java/com/back/domain/member/member/dto/MemberUpdateDto.java
@@ -14,6 +14,7 @@ public record MemberUpdateDto(
         String name,
 
         @NotBlank
+        @Size(min = 8, max = 20)
         String password
 ) {
 }

--- a/src/main/java/com/back/domain/member/member/dto/MemberUpdateDto.java
+++ b/src/main/java/com/back/domain/member/member/dto/MemberUpdateDto.java
@@ -1,0 +1,19 @@
+package com.back.domain.member.member.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record MemberUpdateDto(
+        @NotBlank
+        @Email
+        String email,
+
+        @NotBlank
+        @Size(min = 2, max = 30)
+        String name,
+
+        @NotBlank
+        String password
+) {
+}

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -137,4 +137,14 @@ public class Member {
                 .findFirst();
     }
 
+    public void modifyInfo(String email, String password, String name) {
+        if (name != null && !name.isBlank())
+            this.name = name;
+
+        if (email != null && !email.isBlank())
+            this.email = email;
+
+        if (password != null && !password.isBlank())
+            this.password = password;
+    }
 }

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -1,11 +1,14 @@
 package com.back.domain.member.member.service;
 
+import com.back.domain.member.member.dto.MemberUpdateDto;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
 import com.back.global.exception.ServiceException;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Map;
 import java.util.Optional;
@@ -80,5 +83,16 @@ public class MemberService {
 
 
         memberRepository.delete(member);
+    }
+
+    @Transactional
+    public void modify(@Valid MemberUpdateDto reqBody, Member member) {
+
+        member.modifyInfo(
+                reqBody.email(),
+                passwordEncoder.encode(reqBody.password()),
+                reqBody.name()
+        );
+        memberRepository.save(member);
     }
 }

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -25,6 +25,10 @@ public class MemberService {
         return memberRepository.findByEmail(email);
     }
 
+    public Optional<Member> findById(Long id) {
+        return memberRepository.findById(id);
+    }
+
     public Member join(String email, String password, String name) {
         memberRepository
                 .findByEmail(email)

--- a/src/test/java/com/back/domain/member/address/controller/AddressControllerTest.java
+++ b/src/test/java/com/back/domain/member/address/controller/AddressControllerTest.java
@@ -142,7 +142,6 @@ class AddressControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         get("/api/addresses")
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 
@@ -171,7 +170,6 @@ class AddressControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         get("/api/addresses")
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 
@@ -191,7 +189,6 @@ class AddressControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         get("/api/addresses")
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 
@@ -215,7 +212,6 @@ class AddressControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         delete("/api/addresses/" + address.getId())
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 
@@ -241,7 +237,6 @@ class AddressControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         delete("/api/addresses/" + address.getId())
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 
@@ -267,7 +262,6 @@ class AddressControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         delete("/api/addresses/9999") // 존재하지 않는 주소 ID
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -17,8 +17,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -194,7 +193,6 @@ class MemberControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         delete("/api/members/withdraw")
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 
@@ -217,7 +215,6 @@ class MemberControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         delete("/api/members/withdraw")
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 
@@ -236,7 +233,6 @@ class MemberControllerTest {
         ResultActions resultActions = mvc
                 .perform(
                         delete("/api/members/withdraw")
-                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print());
 
@@ -245,4 +241,30 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.code").value(401))
                 .andExpect(jsonPath("$.message").value("로그인 후 이용해주세요."));
     }
+
+    @Test
+    @DisplayName("회원 정보 조회")
+    @WithUserDetails("user1@gmail.com")
+    void getMemberInfo() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/members/info")
+                )
+                .andDo(print());
+
+        Member member = memberService.findByEmail("user1@gmail.com")
+                .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("getMemberInfo"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("회원 정보가 조회됐습니다."))
+                .andExpect(jsonPath("$.data.id").value(member.getId()))
+                .andExpect(jsonPath("$.data.email").value(member.getEmail()))
+                .andExpect(jsonPath("$.data.name").value(member.getName()))
+                .andExpect(jsonPath("$.data.isAdmin").value(member.isAdmin()));
+    }
+
 }


### PR DESCRIPTION
## 📢 기능 설명
- 회원 정보 조회 엔드포인트 추가
- 회원 정보 조회 테스트 케이스 추가
- 회원 정보 수정 엔드포인트 추가
- 회원 정보 수정 테스트 케이스 추가
- 회원 정보 받기 위한 Dto 선언
<br>

## 연결된 issue
조회, 수정 둘 다 한번에 처리.
close #18 
close #19 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 현재 회원의 상세 정보를 조회하는 API 엔드포인트가 추가되었습니다.
  * 회원 정보(이메일, 이름, 비밀번호)를 수정하는 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 회원 탈퇴 시, 존재하지 않는 회원일 경우 404 오류가 반환되도록 개선되었습니다.

* **테스트**
  * 회원 정보 조회 및 수정 기능에 대한 테스트가 추가되었습니다.
  * 불필요한 contentType 지정이 일부 테스트에서 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->