### PR TITLE
[refactor] 주문 처리 상태 enum으로 구현, 주문 취소시 상태만 변경#1

### DIFF
--- a/src/main/java/com/back/domain/order/controller/OrderController.java
+++ b/src/main/java/com/back/domain/order/controller/OrderController.java
@@ -44,7 +44,7 @@ public class OrderController {
     }
 
     @PostMapping
-    @Operation(summary = "주문 생성") // (더미 상품/멤버 사용)
+    @Operation(summary = "주문 생성")
     public RsData<OrderDto> createOrder(@Valid @RequestBody OrderCreateReqBody reqBody) {
         Member actor = rq.getActor();
         List<OrderItemParam> orderItemParams = reqBody.orderItems()
@@ -91,9 +91,9 @@ public class OrderController {
     //주문 취소
     @DeleteMapping("/{orderId}")
     @Operation(summary = "주문 취소")
-    public RsData<Void> deleteOrder(@PathVariable Long orderId) {
+    public RsData<Void> cancelOrder(@PathVariable Long orderId) {
         Member actor = rq.getActor();
-        orderService.delete(orderId, actor);
+        orderService.cancelOrder(orderId, actor);
         return new RsData<>(
                 200,
                 "%d번 주문이 취소되었습니다.".formatted(orderId),

--- a/src/main/java/com/back/domain/order/dto/OrderDto.java
+++ b/src/main/java/com/back/domain/order/dto/OrderDto.java
@@ -1,6 +1,7 @@
 package com.back.domain.order.dto;
 
 import com.back.domain.order.entity.Order;
+import com.back.domain.order.entity.OrderStatus;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -18,8 +19,8 @@ public record OrderDto(
         @Schema(description = "주문 날짜")
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         @NonNull LocalDateTime createdDate,
-        @Schema(description = "처리 상태")
-        @NonNull String state,
+        @Schema(description = "처리 상태", example = "ORDERED", allowableValues = {"ORDERED", "PAID", "SHIPPING", "COMPLETED", "CANCELED"})
+        @NonNull OrderStatus state,
         @Schema(description = "주문 주소")
         @NonNull String customerAddress,
         @Schema(description = "주문 상세 목록")
@@ -31,7 +32,7 @@ public record OrderDto(
                 order.getId(),
                 order.getCustomer().getEmail(),
                 order.getCreatedDate(),
-                order.getState(),
+                order.getStatus(),
                 order.getCustomerAddress(),
                 null
         );

--- a/src/main/java/com/back/domain/order/dto/OrderDtoWithSpecific.java
+++ b/src/main/java/com/back/domain/order/dto/OrderDtoWithSpecific.java
@@ -1,17 +1,27 @@
 package com.back.domain.order.dto;
 
 import com.back.domain.order.entity.Order;
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 
+@Schema(description = "주문 상세 정보 DTO")
 public record OrderDtoWithSpecific(
+        @Schema(description = "주문 ID")
         Long id,
+        @Schema(description = "주문자 이메일")
         String customerEmail,
+        @Schema(description = "주문 배송 주소")
         String customerAddress,
+        @Schema(description = "주문 상태 코드", example = "ORDERED", allowableValues = {"ORDERED", "PAID", "SHIPPING", "COMPLETED", "CANCELED"})
         String state,
+        @Schema(description = "주문 생성일", example = "2025-07-18 14:00:00")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
         LocalDateTime createdDate,
+        @Schema(description = "주문에 포함된 상품 목록")
         List<OrderItemDto> orderItems
 ) {
     // 주문 상세 조회 (아이템 포함)
@@ -20,7 +30,7 @@ public record OrderDtoWithSpecific(
                 order.getId(),
                 order.getCustomer().getEmail(),
                 order.getCustomerAddress(),
-                order.getState(),
+                order.getStatus().name(),
                 order.getCreatedDate(),
                 order.getOrderItems().stream().map(OrderItemDto::new).toList()
         );

--- a/src/main/java/com/back/domain/order/entity/Order.java
+++ b/src/main/java/com/back/domain/order/entity/Order.java
@@ -41,16 +41,18 @@ public class Order {
 
     private String customerAddress;
 
-    private String state;
+    @Enumerated(EnumType.STRING) // Enum을 String으로 저장
+    @Column(name = "state")
+    private OrderStatus status;
 
     @OneToMany(mappedBy = "order", fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.REMOVE}, orphanRemoval = true)
     @Builder.Default
     private List<OrderItem> orderItems = new ArrayList<>();
 
-    public Order(Member customer, String customerAddress, String state) {
+    public Order(Member customer, String customerAddress) {
         this.customer = customer;
         this.customerAddress = customerAddress;
-        this.state = state;
+        this.status = OrderStatus.ORDERED;
         this.orderItems = new ArrayList<>();
     }
 
@@ -62,4 +64,21 @@ public class Order {
     public void changeCustomerAddress(String customerAddress) {
         this.customerAddress = customerAddress;
     }
+
+    public void changeStatus(OrderStatus newState) {
+        this.status = newState;
+    }
+
+    public void cancel() {
+        if (this.status == OrderStatus.COMPLETED || this.status == OrderStatus.CANCELED) {
+            throw new IllegalStateException("이미 처리된 주문은 취소할 수 없습니다.");
+        }
+        this.status = OrderStatus.CANCELED;
+    }
+    public boolean isCanceled() {
+        return this.status == OrderStatus.CANCELED;
+    }
 }
+
+
+

--- a/src/main/java/com/back/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/back/domain/order/entity/OrderStatus.java
@@ -1,0 +1,19 @@
+package com.back.domain.order.entity;
+
+public enum OrderStatus {
+    ORDERED("주문완료"),
+    PAID("결제완료"),
+    SHIPPING("배송중"),
+    COMPLETED("배송완료"),
+    CANCELED("주문취소");
+
+    private final String description;
+
+    OrderStatus(String description) {
+        this.description = description;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+}

--- a/src/main/java/com/back/domain/order/service/OrderService.java
+++ b/src/main/java/com/back/domain/order/service/OrderService.java
@@ -4,6 +4,7 @@ import com.back.domain.member.member.entity.Member;
 import com.back.domain.order.dto.OrderItemParam;
 import com.back.domain.order.entity.Order;
 import com.back.domain.order.entity.OrderItem;
+import com.back.domain.order.entity.OrderStatus;
 import com.back.domain.order.repository.OrderRepository;
 import com.back.domain.product.entity.Product;
 import com.back.domain.product.repository.ProductRepository;
@@ -24,7 +25,7 @@ public class OrderService {
     @Transactional
     public Order createOrder(Member actor, String customerAddress, List<OrderItemParam> OrderItemParam) {
 
-        Order order = new Order(actor, customerAddress, "ORDERED");
+        Order order = new Order(actor, customerAddress);
 
         for (OrderItemParam param : OrderItemParam) {
             Product product = productRepository.findById(param.productId())
@@ -51,15 +52,19 @@ public class OrderService {
     }
 
     @Transactional
-    public void delete(Long orderId, Member actor) {
+    public void cancelOrder(Long orderId, Member actor) {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new ServiceException(404, "해당 주문이 존재하지 않습니다."));
 
         if (!order.getCustomer().getId().equals(actor.getId())) {
-            throw new ServiceException(403, "%d번 주문 삭제 권한이 없습니다.".formatted(order.getId()));
+            throw new ServiceException(403, "%d번 주문 취소 권한이 없습니다.".formatted(order.getId()));
         }
 
-        orderRepository.delete(order);
+        if (order.isCanceled()) {
+            throw new ServiceException(409, "이미 취소된 주문입니다.");
+        }
+
+        order.changeStatus(OrderStatus.CANCELED);
     }
 
     @Transactional
@@ -69,6 +74,10 @@ public class OrderService {
 
         if (!order.getCustomer().getId().equals(actor.getId())) {
             throw new ServiceException(403, "%d번 주문 주소 변경 권한이 없습니다.".formatted(order.getId()));
+        }
+
+        if (order.isCanceled()) {
+            throw new ServiceException(409, "이미 취소된 주문입니다.");
         }
 
         order.changeCustomerAddress(newAddress);

--- a/src/test/java/com/back/domain/order/controller/OrderControllerTest.java
+++ b/src/test/java/com/back/domain/order/controller/OrderControllerTest.java
@@ -163,12 +163,12 @@ public class OrderControllerTest {
     @Test
     @WithUserDetails("user2@gmail.com")
     @Order(9)
-    @DisplayName("9. 주문 삭제 실패 - 권한 없음")
+    @DisplayName("9. 주문 취소 실패 - 권한 없음")
     void t9() throws Exception {
 
         performWithPrint(delete("/api/orders/{orderId}", savedOrderId))
                 .andExpect(jsonPath("$.code").value(403))
-                .andExpect(jsonPath("$.message").value( "%s번 주문 삭제 권한이 없습니다.".formatted(savedOrderId)));
+                .andExpect(jsonPath("$.message").value( "%s번 주문 취소 권한이 없습니다.".formatted(savedOrderId)));
     }
 
     @Test
@@ -189,19 +189,20 @@ public class OrderControllerTest {
     @Test
     @WithUserDetails("user1@gmail.com")
     @Order(11)
-    @DisplayName("11. 주문 취소 후 조회 시 404 확인")
+    @DisplayName("11. 주문 취소 후 조회 시 CANCEL 상태 확인")
     void t11() throws Exception {
         Assertions.assertNotNull(savedOrderId, "삭제된 주문 ID가 null입니다.");
 
         performWithPrint(get("/api/orders/{orderId}/detail", savedOrderId))
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value("해당 주문이 존재하지 않습니다."));
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.data.state").value("CANCELED"));
     }
 
     @Test
     @WithUserDetails("user1@gmail.com")
     @Order(12)
-    @DisplayName("12. 주문 삭제 실패 - 존재하지 않는 주문")
+    @DisplayName("12. 주문 취소 실패 - 존재하지 않는 주문")
     void t12() throws Exception {
         Long nonExistentOrderId = 999999L;
 


### PR DESCRIPTION
## 📢 기능 설명

필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #99
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 주문 상태를 문자열에서 enum(OrderStatus) 타입으로 변경하여 더 명확하게 관리합니다.
  * 주문 상태별 한글 설명이 추가되어 사용자에게 더 친절한 상태 안내가 제공됩니다.

* **버그 수정**
  * 주문 취소 시 이미 취소된 주문이나 완료된 주문은 다시 취소할 수 없도록 예외 처리가 강화되었습니다.
  * 취소된 주문의 배송지 정보는 수정할 수 없도록 제한되었습니다.

* **문서화**
  * 주문 관련 DTO에 Swagger(OpenAPI) 어노테이션이 추가되어 API 문서가 더 명확해졌습니다.
  * 주문 생성일의 날짜 포맷이 명시적으로 지정되었습니다.

* **리팩터링**
  * 주문 삭제 기능이 주문 취소로 변경되어, 주문 데이터가 실제로 삭제되지 않고 상태만 변경됩니다.
  * 관련 메서드 및 테스트 명칭이 "삭제"에서 "취소"로 일관성 있게 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->