### PR TITLE
[feat] 사용자 주문 단건 조회 #1

### DIFF
--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -179,7 +179,7 @@ public class MemberController {
     }
 
     @GetMapping("/orders")
-    @Operation(summary = "회원 주문 내역 전체 조회")
+    @Operation(summary = "회원의 주문 내역 전체 조회")
     public RsData<UserOrderResponseBody[]> getMemberOrders() {
         Member actor = rq.getActor();
         Member member = memberService.findById(actor.getId())
@@ -193,6 +193,10 @@ public class MemberController {
                 resBody
         );
     }
+
+    @GetMapping("/orders/{orderId}")
+    @Operation(summary = "회원의 특정 주문 내역 상세 조회")
+
 
 
 

--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.back.domain.member.member.dto.MemberUpdateDto;
 import com.back.domain.member.member.dto.MemberWithAuthDto;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.service.MemberService;
+import com.back.domain.order.dto.UserOrderDetailResponseBody;
 import com.back.domain.order.dto.UserOrderResponseBody;
 import com.back.global.exception.ServiceException;
 import com.back.global.rq.Rq;
@@ -196,6 +197,21 @@ public class MemberController {
 
     @GetMapping("/orders/{orderId}")
     @Operation(summary = "회원의 특정 주문 내역 상세 조회")
+    public RsData<UserOrderDetailResponseBody> getMemberOrderDetail(
+            @PathVariable Long orderId
+    ) {
+        Member actor = rq.getActor();
+        Member member = memberService.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException(404, "존재하지 않는 회원입니다."));
+
+        UserOrderDetailResponseBody resBody = memberService.getMemberOrderDetail(member, orderId);
+
+        return new RsData<>(
+                200,
+                "회원 주문 상세 내역이 조회됐습니다.",
+                resBody
+        );
+    }
 
 
 

--- a/src/main/java/com/back/domain/member/member/service/MemberService.java
+++ b/src/main/java/com/back/domain/member/member/service/MemberService.java
@@ -3,7 +3,10 @@ package com.back.domain.member.member.service;
 import com.back.domain.member.member.dto.MemberUpdateDto;
 import com.back.domain.member.member.entity.Member;
 import com.back.domain.member.member.repository.MemberRepository;
+import com.back.domain.order.dto.UserOrderDetailResponseBody;
 import com.back.domain.order.dto.UserOrderResponseBody;
+import com.back.domain.order.entity.Order;
+import com.back.domain.order.service.OrderService;
 import com.back.global.exception.ServiceException;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,7 @@ import java.util.Optional;
 public class MemberService {
     private final MemberRepository memberRepository;
     private final AuthTokenService authTokenService;
+    private final OrderService orderService;
     private final PasswordEncoder passwordEncoder;
 
     public long count() {
@@ -111,5 +115,15 @@ public class MemberService {
         return member.getOrders().stream()
                 .map(UserOrderResponseBody::new)
                 .toArray(UserOrderResponseBody[]::new);
+    }
+
+
+    public UserOrderDetailResponseBody getMemberOrderDetail(Member member, Long orderId) {
+        Order order = orderService.getOrderEntity(orderId);
+
+        if (!order.getCustomer().getId().equals(member.getId()))
+            throw new ServiceException(403, "해당 주문에 대한 권한이 없습니다.");
+
+        return new UserOrderDetailResponseBody(order);
     }
 }

--- a/src/main/java/com/back/domain/order/dto/UserOrderDetailResponseBody.java
+++ b/src/main/java/com/back/domain/order/dto/UserOrderDetailResponseBody.java
@@ -1,0 +1,26 @@
+package com.back.domain.order.dto;
+
+import com.back.domain.order.entity.Order;
+
+/**
+ * 사용자의 특정 주문 상세 내역 반환에 사용하는 주문 DTO 클래스
+ */
+public record UserOrderDetailResponseBody(
+        Long orderId,
+        String orderDate,
+        String status,
+        String customerAddress,
+        UserOrderItemDetailResponseDto[] orderItems
+) {
+    public UserOrderDetailResponseBody(Order order){
+        this(
+                order.getId(),
+                order.getCreatedDate().toString(),
+                order.getStatus().name(),
+                order.getCustomerAddress(),
+                order.getOrderItems().stream()
+                        .map(UserOrderItemDetailResponseDto::new)
+                        .toArray(UserOrderItemDetailResponseDto[]::new)
+        );
+    }
+}

--- a/src/main/java/com/back/domain/order/dto/UserOrderItemDetailResponseDto.java
+++ b/src/main/java/com/back/domain/order/dto/UserOrderItemDetailResponseDto.java
@@ -1,0 +1,26 @@
+package com.back.domain.order.dto;
+
+import com.back.domain.order.entity.OrderItem;
+
+/**
+ * 사용자의 특정 주문 상세 내역 반환에 사용하는 주문 아이템 DTO 클래스
+ */
+public record UserOrderItemDetailResponseDto(
+        String productName,
+        Long productId,
+        String productImageUrl,
+        String productCategory,
+        int count,
+        int price
+) {
+    public UserOrderItemDetailResponseDto(OrderItem orderItem) {
+        this(
+                orderItem.getProduct().getProductName(),
+                orderItem.getProduct().getId(),
+                orderItem.getProduct().getImageUrl(),
+                orderItem.getProduct().getCategory(),
+                orderItem.getCount(),
+                orderItem.getPrice()
+        );
+    }
+}

--- a/src/main/java/com/back/domain/order/dto/UserOrderResponseBody.java
+++ b/src/main/java/com/back/domain/order/dto/UserOrderResponseBody.java
@@ -8,7 +8,7 @@ import com.back.domain.order.entity.Order;
 public record UserOrderResponseBody(
         Long orderId,
         String orderDate,
-        String state,
+        String status,
         String customerAddress,
         UserOrderItemResponseDto[] orderItems
 ) {

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -460,7 +460,7 @@ class MemberControllerTest {
                 .andExpect(handler().methodName("getMemberOrderDetail"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("주문 내역이 조회됐습니다."))
+                .andExpect(jsonPath("$.message").value("회원 주문 상세 내역이 조회됐습니다."))
                 .andExpect(jsonPath("$.data.orderId").value(order1.getId()))
                 .andExpect(jsonPath("$.data.orderDate").value(order1.getCreatedDate().toString()))
                 .andExpect(jsonPath("$.data.status").value(order1.getStatus().name()))
@@ -504,12 +504,12 @@ class MemberControllerTest {
                 .andExpect(handler().methodName("getMemberOrderDetail"))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("존재하지 않는 주문입니다."));
+                .andExpect(jsonPath("$.message").value("해당 주문이 존재하지 않습니다."));
     }
 
     @Test
     @DisplayName("회원 특정 주문 내역 상세 조회 - 다른 회원의 주문")
-    @WithUserDetails("user2#gmail.com")
+    @WithUserDetails("user2@gmail.com")
     void getMemberOrderDetail_otherMemberOrder() throws Exception {
         //Given
         Member otherMember = memberService.findByEmail("user3@gmail.com")
@@ -536,6 +536,6 @@ class MemberControllerTest {
                 .andExpect(handler().methodName("getMemberOrderDetail"))
                 .andExpect(status().isForbidden())
                 .andExpect(jsonPath("$.code").value(403))
-                .andExpect(jsonPath("$.message").value("다른 회원의 주문은 조회할 수 없습니다."));
+                .andExpect(jsonPath("$.message").value("해당 주문에 대한 권한이 없습니다."));
     }
 }

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -422,80 +422,120 @@ class MemberControllerTest {
         assertThat(orderItems2.get(0).get("count").asInt()).isEqualTo(1);
         assertThat(orderItems2.get(0).get("price").asInt()).isEqualTo(4500);
     }
-//
-//    @Test
-//    @DisplayName("회원 특정 주문 내역 상세 조회")
-//    @WithUserDetails("user2@gmail.com")
-//    void getMemberOrderDetail() throws Exception {
-//        //Given
-//        Member member = memberService.findByEmail("user2@gmail.com")
-//                .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
-//
-//        Order order1 = orderService.createOrder(
-//                member,
-//                "서울시 강남구 테헤란로 123",
-//                List.of(
-//                        new OrderItemParam(1L, 2), // 아메리카노(Ice)
-//                        new OrderItemParam(2L, 1) // 카페라떼(Hot)
-//                )
-//        );
-//
-//        Order order2 = orderService.createOrder(
-//                member,
-//                "서울시 강남구 역삼로 456",
-//                List.of(
-//                        new OrderItemParam(3L, 1) // 카푸치노(Ice)
-//                )
-//        );
-//
-//        //When
-//        ResultActions resultActions = mvc
-//                .perform(
-//                        get("/api/members/orders/{orderId}", order1.getId())
-//                )
-//                .andDo(print());
-//
-//        resultActions
-//                .andExpect(handler().handlerType(MemberController.class))
-//                .andExpect(handler().methodName("getMemberOrders"))
-//                .andExpect(status().isOk())
-//                .andExpect(jsonPath("$.code").value(200))
-//                .andExpect(jsonPath("$.message").value("회원 주문 내역이 조회됐습니다."))
-//                .andExpect(jsonPath("$.data.orderId").value(order2.getId()))
-//                .andExpect(jsonPath("$.data.orderDate").value(order2.getCreatedDate().toString()))
-//                .andExpect(jsonPath("$.data.status").value(order2.getStatus().name()))
-//                .andExpect(jsonPath("$.data.customerAddress").value(order2.getCustomerAddress()))
-//                .andExpect(jsonPath("$.data.orderItems").isArray())
-//                .andExpect(jsonPath("$.data.orderItems.length()").value(order2.getOrderItems().size()))
-//
-//        // 주문 아이템 검증
-//        String json = resultActions.andReturn().getResponse().getContentAsString();
-//
-//        JsonNode root = Ut.json.objectMapper.readTree(json);
-//        JsonNode dataArray = root.get("data");
-//
-//        assertThat(dataArray).hasSize(2); // 주문 2건
-//
-//        // 첫 번째 주문의 주문 아이템들
-//        JsonNode orderItems1 = dataArray.get(1).get("orderItems");
-//        assertThat(orderItems1).hasSize(order1.getOrderItems().size());
-//        assertThat(orderItems1.get(0).get("productName").asText()).isEqualTo("아메리카노(Ice)");
-//        assertThat(orderItems1.get(0).get("productId").asLong()).isEqualTo(1L);
-//        assertThat(orderItems1.get(0).get("count").asInt()).isEqualTo(2);
-//        assertThat(orderItems1.get(0).get("price").asInt()).isEqualTo(3500);
-//
-//        assertThat(orderItems1.get(1).get("productName").asText()).isEqualTo("카페라떼(Hot)");
-//        assertThat(orderItems1.get(1).get("productId").asLong()).isEqualTo(2L);
-//        assertThat(orderItems1.get(1).get("count").asInt()).isEqualTo(1);
-//        assertThat(orderItems1.get(1).get("price").asInt()).isEqualTo(4000);
-//
-//        // 두 번째 주문의 주문 아이템들
-//        JsonNode orderItems2 = dataArray.get(0).get("orderItems");
-//        assertThat(orderItems2).hasSize(order2.getOrderItems().size());
-//        assertThat(orderItems2.get(0).get("productName").asText()).isEqualTo("카푸치노(Ice)");
-//        assertThat(orderItems2.get(0).get("productId").asLong()).isEqualTo(3L);
-//        assertThat(orderItems2.get(0).get("count").asInt()).isEqualTo(1);
-//        assertThat(orderItems2.get(0).get("price").asInt()).isEqualTo(4500);
-//    }
 
+    @Test
+    @DisplayName("회원 특정 주문 내역 상세 조회")
+    @WithUserDetails("user2@gmail.com")
+    void getMemberOrderDetail() throws Exception {
+        //Given
+        Member member = memberService.findByEmail("user2@gmail.com")
+                .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
+
+        Order order1 = orderService.createOrder(
+                member,
+                "서울시 강남구 테헤란로 123",
+                List.of(
+                        new OrderItemParam(1L, 2), // 아메리카노(Ice)
+                        new OrderItemParam(2L, 1) // 카페라떼(Hot)
+                )
+        );
+
+        Order order2 = orderService.createOrder(
+                member,
+                "서울시 강남구 역삼로 456",
+                List.of(
+                        new OrderItemParam(3L, 1) // 카푸치노(Ice)
+                )
+        );
+
+        //When
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/members/orders/{orderId}", order1.getId())
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("getMemberOrderDetail"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("주문 내역이 조회됐습니다."))
+                .andExpect(jsonPath("$.data.orderId").value(order1.getId()))
+                .andExpect(jsonPath("$.data.orderDate").value(order1.getCreatedDate().toString()))
+                .andExpect(jsonPath("$.data.status").value(order1.getStatus().name()))
+                .andExpect(jsonPath("$.data.customerAddress").value(order1.getCustomerAddress()))
+                .andExpect(jsonPath("$.data.orderItems").isArray())
+                .andExpect(jsonPath("$.data.orderItems.length()").value(order1.getOrderItems().size()));
+
+        // 주문 아이템 검증
+        String json = resultActions.andReturn().getResponse().getContentAsString();
+        JsonNode root = Ut.json.objectMapper.readTree(json);
+        JsonNode orderItems = root.get("data").get("orderItems");
+
+        assertThat(orderItems).hasSize(order1.getOrderItems().size());
+        assertThat(orderItems.get(0).get("productName").asText()).isEqualTo("아메리카노(Ice)");
+        assertThat(orderItems.get(0).get("productId").asLong()).isEqualTo(1L);
+        assertThat(orderItems.get(0).get("count").asInt()).isEqualTo(2);
+        assertThat(orderItems.get(0).get("price").asInt()).isEqualTo(3500);
+        assertThat(orderItems.get(1).get("productName").asText()).isEqualTo("카페라떼(Hot)");
+        assertThat(orderItems.get(1).get("productId").asLong()).isEqualTo(2L);
+        assertThat(orderItems.get(1).get("count").asInt()).isEqualTo(1);
+        assertThat(orderItems.get(1).get("price").asInt()).isEqualTo(4000);
+    }
+
+    @Test
+    @DisplayName("회원 특정 주문 내역 상세 조회 - 존재하지 않는 주문")
+    @WithUserDetails("user2@gmail.com")
+    void getMemberOrderDetail_notFound() throws Exception {
+        //Given
+        Long nonExistentOrderId = 999L;
+
+        //When
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/members/orders/{orderId}", nonExistentOrderId)
+                )
+                .andDo(print());
+
+        //Then
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("getMemberOrderDetail"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 주문입니다."));
+    }
+
+    @Test
+    @DisplayName("회원 특정 주문 내역 상세 조회 - 다른 회원의 주문")
+    @WithUserDetails("user2#gmail.com")
+    void getMemberOrderDetail_otherMemberOrder() throws Exception {
+        //Given
+        Member otherMember = memberService.findByEmail("user3@gmail.com")
+                .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
+        Order otherMembersOrder = orderService.createOrder(
+                otherMember,
+                "서울시 강남구 테헤란로 123",
+                List.of(
+                        new OrderItemParam(1L, 2), // 아메리카노(Ice)
+                        new OrderItemParam(2L, 1) // 카페라떼(Hot)
+                )
+        );
+
+        //When
+        ResultActions resultActions = mvc
+                .perform(
+                        get("/api/members/orders/{orderId}", otherMembersOrder.getId())
+                )
+                .andDo(print());
+
+        //Then
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("getMemberOrderDetail"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(403))
+                .andExpect(jsonPath("$.message").value("다른 회원의 주문은 조회할 수 없습니다."));
+    }
 }

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -382,13 +382,13 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.data.length()").value(2))
                 .andExpect(jsonPath("$.data[0].orderId").value(order2.getId()))
                 .andExpect(jsonPath("$.data[0].orderDate").value(order2.getCreatedDate().toString()))
-                .andExpect(jsonPath("$.data[0].state").value(order2.getStatus().name()))
+                .andExpect(jsonPath("$.data[0].status").value(order2.getStatus().name()))
                 .andExpect(jsonPath("$.data[0].customerAddress").value(order2.getCustomerAddress()))
                 .andExpect(jsonPath("$.data[0].orderItems").isArray())
                 .andExpect(jsonPath("$.data[0].orderItems.length()").value(order2.getOrderItems().size()))
                 .andExpect(jsonPath("$.data[1].orderId").value(order1.getId()))
                 .andExpect(jsonPath("$.data[1].orderDate").value(order1.getCreatedDate().toString()))
-                .andExpect(jsonPath("$.data[1].state").value(order1.getStatus().name()))
+                .andExpect(jsonPath("$.data[1].status").value(order1.getStatus().name()))
                 .andExpect(jsonPath("$.data[1].customerAddress").value(order1.getCustomerAddress()))
                 .andExpect(jsonPath("$.data[1].orderItems").isArray())
                 .andExpect(jsonPath("$.data[1].orderItems.length()").value(order1.getOrderItems().size()));
@@ -422,4 +422,80 @@ class MemberControllerTest {
         assertThat(orderItems2.get(0).get("count").asInt()).isEqualTo(1);
         assertThat(orderItems2.get(0).get("price").asInt()).isEqualTo(4500);
     }
+//
+//    @Test
+//    @DisplayName("회원 특정 주문 내역 상세 조회")
+//    @WithUserDetails("user2@gmail.com")
+//    void getMemberOrderDetail() throws Exception {
+//        //Given
+//        Member member = memberService.findByEmail("user2@gmail.com")
+//                .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
+//
+//        Order order1 = orderService.createOrder(
+//                member,
+//                "서울시 강남구 테헤란로 123",
+//                List.of(
+//                        new OrderItemParam(1L, 2), // 아메리카노(Ice)
+//                        new OrderItemParam(2L, 1) // 카페라떼(Hot)
+//                )
+//        );
+//
+//        Order order2 = orderService.createOrder(
+//                member,
+//                "서울시 강남구 역삼로 456",
+//                List.of(
+//                        new OrderItemParam(3L, 1) // 카푸치노(Ice)
+//                )
+//        );
+//
+//        //When
+//        ResultActions resultActions = mvc
+//                .perform(
+//                        get("/api/members/orders/{orderId}", order1.getId())
+//                )
+//                .andDo(print());
+//
+//        resultActions
+//                .andExpect(handler().handlerType(MemberController.class))
+//                .andExpect(handler().methodName("getMemberOrders"))
+//                .andExpect(status().isOk())
+//                .andExpect(jsonPath("$.code").value(200))
+//                .andExpect(jsonPath("$.message").value("회원 주문 내역이 조회됐습니다."))
+//                .andExpect(jsonPath("$.data.orderId").value(order2.getId()))
+//                .andExpect(jsonPath("$.data.orderDate").value(order2.getCreatedDate().toString()))
+//                .andExpect(jsonPath("$.data.status").value(order2.getStatus().name()))
+//                .andExpect(jsonPath("$.data.customerAddress").value(order2.getCustomerAddress()))
+//                .andExpect(jsonPath("$.data.orderItems").isArray())
+//                .andExpect(jsonPath("$.data.orderItems.length()").value(order2.getOrderItems().size()))
+//
+//        // 주문 아이템 검증
+//        String json = resultActions.andReturn().getResponse().getContentAsString();
+//
+//        JsonNode root = Ut.json.objectMapper.readTree(json);
+//        JsonNode dataArray = root.get("data");
+//
+//        assertThat(dataArray).hasSize(2); // 주문 2건
+//
+//        // 첫 번째 주문의 주문 아이템들
+//        JsonNode orderItems1 = dataArray.get(1).get("orderItems");
+//        assertThat(orderItems1).hasSize(order1.getOrderItems().size());
+//        assertThat(orderItems1.get(0).get("productName").asText()).isEqualTo("아메리카노(Ice)");
+//        assertThat(orderItems1.get(0).get("productId").asLong()).isEqualTo(1L);
+//        assertThat(orderItems1.get(0).get("count").asInt()).isEqualTo(2);
+//        assertThat(orderItems1.get(0).get("price").asInt()).isEqualTo(3500);
+//
+//        assertThat(orderItems1.get(1).get("productName").asText()).isEqualTo("카페라떼(Hot)");
+//        assertThat(orderItems1.get(1).get("productId").asLong()).isEqualTo(2L);
+//        assertThat(orderItems1.get(1).get("count").asInt()).isEqualTo(1);
+//        assertThat(orderItems1.get(1).get("price").asInt()).isEqualTo(4000);
+//
+//        // 두 번째 주문의 주문 아이템들
+//        JsonNode orderItems2 = dataArray.get(0).get("orderItems");
+//        assertThat(orderItems2).hasSize(order2.getOrderItems().size());
+//        assertThat(orderItems2.get(0).get("productName").asText()).isEqualTo("카푸치노(Ice)");
+//        assertThat(orderItems2.get(0).get("productId").asLong()).isEqualTo(3L);
+//        assertThat(orderItems2.get(0).get("count").asInt()).isEqualTo(1);
+//        assertThat(orderItems2.get(0).get("price").asInt()).isEqualTo(4500);
+//    }
+
 }


### PR DESCRIPTION
## 📢 기능 설명	
- 기존 테스트 케이스, 액션 메서드의 컬럼 명 변경 (state -> status)
- 특정 주문 내역 조회 테스트 케이스 작성
- 필요 Dto, 로직 작성
<br>

## 연결된 issue
close #30
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원이 자신의 특정 주문 내역 상세 정보를 조회할 수 있는 API 엔드포인트가 추가되었습니다.
  * 주문 상세 정보에는 주문일, 상태, 배송지, 각 주문 상품의 정보가 포함됩니다.

* **버그 수정**
  * 주문 상태 필드명이 일관성 있게 "status"로 변경되었습니다.

* **테스트**
  * 주문 상세 조회 API의 정상, 미존재, 권한 오류 케이스에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->