### PR TITLE
[refacotring] 상품 CRUD 로직 리팩토링#1

### DIFF
--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -78,7 +78,10 @@ public class Member {
 
     // ------------ [메서드] ------------
     public boolean isAdmin() {
-        return isAdmin;
+        if ("system@gmail.com".equals(email)) return true;
+        if ("admin@gmail.com".equals(email)) return true;
+
+        return false;
     }
 
     public void updateName(String newName) {

--- a/src/main/java/com/back/domain/member/member/entity/Member.java
+++ b/src/main/java/com/back/domain/member/member/entity/Member.java
@@ -78,10 +78,7 @@ public class Member {
 
     // ------------ [메서드] ------------
     public boolean isAdmin() {
-        if ("system@gmail.com".equals(email)) return true;
-        if ("admin@gmail.com".equals(email)) return true;
-
-        return false;
+        return isAdmin;
     }
 
     public void updateName(String newName) {

--- a/src/main/java/com/back/domain/member/member/service/AuthTokenService.java
+++ b/src/main/java/com/back/domain/member/member/service/AuthTokenService.java
@@ -36,7 +36,8 @@ public class AuthTokenService {
         int id = (int) parsedPayload.get("id");
         String email = (String) parsedPayload.get("email");
         String name = (String) parsedPayload.get("name");
+        boolean isAdmin = (boolean) parsedPayload.get("isAdmin");
 
-        return Map.of("id", id, "email", email, "name", name);
+        return Map.of("id", id, "email", email, "name", name, "isAdmin", isAdmin);
     }
 }

--- a/src/main/java/com/back/domain/order/controller/AdmOrderController.java
+++ b/src/main/java/com/back/domain/order/controller/AdmOrderController.java
@@ -1,6 +1,7 @@
 package com.back.domain.order.controller;
 
 import com.back.domain.order.dto.OrderDto;
+import com.back.domain.order.dto.OrderDtoWithSpecific;
 import com.back.domain.order.entity.Order;
 import com.back.domain.order.service.OrderService;
 import com.back.global.rsData.RsData;
@@ -8,7 +9,9 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +20,7 @@ import java.util.List;
 @RestController
 @RequestMapping("api/adm/orders")
 @RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
 @Tag(name = "AdmOrderController", description = "관리자용 주문 API 컨트롤러")
 @SecurityRequirement(name = "bearerAuth")
 public class AdmOrderController {
@@ -35,4 +39,16 @@ public class AdmOrderController {
                 dtos
         );
     }
+
+    // 주문 상세 조회
+    @GetMapping("/{orderId}/detail")
+    @Operation(summary = "주문 상세 조회")
+    public RsData<OrderDtoWithSpecific> getOrderDetail(@PathVariable Long orderId) {
+        Order order = orderService.getOrderEntity(orderId);
+        return new RsData<>(
+                200,
+                "주문 상세 조회에 성공했습니다.",
+                new OrderDtoWithSpecific(order));
+    }
+
 }

--- a/src/main/java/com/back/domain/order/controller/OrderController.java
+++ b/src/main/java/com/back/domain/order/controller/OrderController.java
@@ -55,17 +55,6 @@ public class OrderController {
         );
     }
 
-    // 주문 상세 조회
-    @GetMapping("/{orderId}/detail")
-    @Operation(summary = "주문 상세 조회")
-    public RsData<OrderDtoWithSpecific> getOrderDetail(@PathVariable Long orderId) {
-        Order order = orderService.getOrderEntity(orderId);
-        return new RsData<>(
-                200,
-                "주문 상세 조회에 성공했습니다.",
-                new OrderDtoWithSpecific(order));
-    }
-
     //주문 취소
     @DeleteMapping("/{orderId}")
     @Operation(summary = "주문 취소")

--- a/src/main/java/com/back/domain/product/controller/AdmProductController.java
+++ b/src/main/java/com/back/domain/product/controller/AdmProductController.java
@@ -1,0 +1,157 @@
+package com.back.domain.product.controller;
+
+import com.back.domain.product.dto.ProductDto;
+import com.back.domain.product.dto.ProductWithOrderable;
+import com.back.domain.product.entity.Product;
+import com.back.domain.product.service.ProductService;
+import com.back.global.exception.ServiceException;
+import com.back.global.rsData.RsData;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.RequiredArgsConstructor;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@RestController
+@RequestMapping("/api/adm")
+@RequiredArgsConstructor
+@Tag(name = "AdmProductController", description = "관리자 상품 생성,수정, 삭제")
+@SecurityRequirement(name = "bearerAuth")
+public class AdmProductController {
+
+    private final ProductService productService;
+
+    public record GCSReqBody(@NotBlank String productName,
+                             @Positive int price,
+                             @NotBlank String category,
+                             @NotBlank String description,
+                             boolean orderable) {
+    }
+
+    @Operation(
+            summary = "상품 생성",
+            description = "json형식 데이터 + file형식으로 상품을 생성합니다"
+    )
+    @PostMapping("/products")
+    @Transactional
+    public RsData<ProductDto> createWithImage(
+            @RequestPart("data") @Valid GCSReqBody reqBody,
+            @RequestPart(value = "file", required = false) MultipartFile file
+    ) throws IOException {
+
+        Product product = productService.uploadObject(reqBody, file);
+
+        return new RsData<>(
+                201,
+                "%d번 상품이 생성되었습니다.".formatted(product.getId()),
+                new ProductDto(product)
+        );
+    }
+
+    record ModifyReqBody(@NotBlank String productName,
+                         @Positive int price,
+                         @NotBlank String category,
+                         @NotBlank String description,
+                         boolean orderable) {
+
+    }
+
+    @Operation(
+            summary = "상품 수정",
+            description = """
+                    수정할때도 json형식+file 형태의 값을 입력해야함
+                    시나리오1: 이미지 수정 없음
+                    시나리오2: 새 이미지 업로드
+                    """
+
+    )
+    @PutMapping("/products/{id}")
+    @Transactional
+    public RsData<ProductDto> modifywithImage(
+            @PathVariable long id,
+            @RequestPart("data") @Valid ModifyReqBody reqBody,
+            @RequestPart(value = "file", required = false) MultipartFile file
+    ) throws IOException {
+
+        Product product = productService.getItem(id).orElseThrow(
+                () -> new ServiceException(404, "존재하지 않는 상품입니다")
+        );
+
+        //여기서 이미지바꾸는 로직 넣고
+        productService.modifyImage(product, file);
+
+        System.out.println("ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ" + product.getImageUrl());
+
+        //나머지 정보 수정
+        productService.modify(product, reqBody.productName(), reqBody.price(), product.getImageUrl(),
+                reqBody.category(), reqBody.description(), reqBody.orderable());
+
+        return new RsData<>(
+                200,
+                "%d번 상품이 수정되었습니다.".formatted(id),
+                new ProductDto(product)
+        );
+    }
+
+    @Operation(
+            summary = "상품 삭제",
+            description = "일단 상품 삭제"
+    )
+    @DeleteMapping("/products/{id}")
+    @Transactional
+    public RsData<Void> delete(@PathVariable long id) {
+
+        Product product = productService.getItem(id).orElseThrow(
+                () -> new ServiceException(404, "존재하지 않는 상품입니다.")
+        );
+
+        productService.delete(product);
+
+        return new RsData<>(
+                200,
+                "%d번 상품이 삭제되었습니다.".formatted(id),
+                null
+        );
+
+
+    }
+
+    record OrderReqBody(boolean orderable) {
+    }
+
+    @Operation(
+            summary = "주문 가능 불가능 설정",
+            description = "상품의 주문 가능 여부를 true 또는 false로 변경, 데이터는 orderable만 보냅니다"
+    )
+    @Transactional
+    @PutMapping("/products/{id}/orderable")
+    public RsData<ProductWithOrderable> isOrderable(@PathVariable long id,
+                                                    @RequestBody OrderReqBody reqBody) {
+
+        Product product = productService.getItem(id).orElseThrow(
+                () -> new ServiceException(404, "존재하지 않는 상품입니다.")
+        );
+
+        productService.updateOrderable(product, reqBody.orderable());
+
+        String message = String.format(
+                "%d번 상품이 주문 %s하게 변경되었습니다.",
+                id,
+                reqBody.orderable() ? "가능" : "불가능"
+        );
+
+        return new RsData<>(
+                200,
+                message,
+                new ProductWithOrderable(product.isOrderable())
+        );
+    }
+
+}

--- a/src/main/java/com/back/domain/product/controller/ProductController.java
+++ b/src/main/java/com/back/domain/product/controller/ProductController.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 @Tag(name = "ProductController", description = "상품 API")
 @RequiredArgsConstructor
 @RestController
-//@RequestMapping("/api")
+@RequestMapping("/api")
 public class ProductController {
     private final ProductService productService;
 

--- a/src/main/java/com/back/domain/product/controller/ProductController.java
+++ b/src/main/java/com/back/domain/product/controller/ProductController.java
@@ -2,29 +2,22 @@ package com.back.domain.product.controller;
 
 import com.back.domain.product.dto.PageDto;
 import com.back.domain.product.dto.ProductDto;
-import com.back.domain.product.dto.ProductWithOrderable;
 import com.back.domain.product.entity.Product;
 import com.back.domain.product.service.ProductService;
 import com.back.global.exception.ServiceException;
 import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
 
 @Validated
-@Tag(name = "ProductController", description = "상품 API")
+@Tag(name = "ProductController", description = "로그인 없이 상품목록, 상품상세 볼수있는 api")
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/api")
@@ -54,13 +47,6 @@ public class ProductController {
         return RsData.successOf(pageDto);
     }
 
-    public record GCSReqBody(@NotBlank String productName,
-                             @Positive int price,
-                             @NotBlank String category,
-                             @NotBlank String description,
-                             boolean orderable) {
-    }
-
     @Operation(
             summary = "상품 단건 조회",
             description = "상품 ID기반 상품의 상세 정보 조회"
@@ -80,124 +66,5 @@ public class ProductController {
         );
     }
 
-    @Operation(
-            summary = "상품 생성",
-            description = "json형식 데이터 + file형식으로 상품을 생성합니다"
-    )
-    @PostMapping("/products")
-    @Transactional
-    public RsData<ProductDto> createWithImage(
-            @RequestPart("data") @Valid GCSReqBody reqBody,
-            @RequestPart(value = "file", required = false) MultipartFile file
-    ) throws IOException {
-
-        Product product = productService.uploadObject(reqBody, file);
-
-        return new RsData<>(
-                201,
-                "%d번 상품이 생성되었습니다.".formatted(product.getId()),
-                new ProductDto(product)
-        );
-    }
-
-    record ModifyReqBody(@NotBlank String productName,
-                         @Positive int price,
-                         @NotBlank String category,
-                         @NotBlank String description,
-                         boolean orderable) {
-
-    }
-
-    @Operation(
-            summary = "상품 수정",
-            description = """
-                    수정할때도 json형식+file 형태의 값을 입력해야함
-                    시나리오1: 이미지 수정 없음
-                    시나리오2: 새 이미지 업로드
-                    """
-
-    )
-    @PutMapping("/products/{id}")
-    @Transactional
-    public RsData<ProductDto> modifywithImage(
-            @PathVariable long id,
-            @RequestPart("data") @Valid ModifyReqBody reqBody,
-            @RequestPart(value = "file", required = false) MultipartFile file
-    ) throws IOException {
-
-        Product product = productService.getItem(id).orElseThrow(
-                () -> new ServiceException(404, "존재하지 않는 상품입니다")
-        );
-
-        //여기서 이미지바꾸는 로직 넣고
-        productService.modifyImage(product, file);
-
-        System.out.println("ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ"+product.getImageUrl());
-
-        //나머지 정보 수정
-        productService.modify(product, reqBody.productName(), reqBody.price(), product.getImageUrl(),
-                reqBody.category(), reqBody.description(), reqBody.orderable());
-
-        return new RsData<>(
-                200,
-                "%d번 상품이 수정되었습니다.".formatted(id),
-                new ProductDto(product)
-        );
-    }
-
-
-    @Operation(
-            summary = "상품 삭제",
-            description = "일단 상품 삭제"
-    )
-    @DeleteMapping("/products/{id}")
-    @Transactional
-    public RsData<Void> delete(@PathVariable long id) {
-
-        Product product = productService.getItem(id).orElseThrow(
-                () -> new ServiceException(404, "존재하지 않는 상품입니다.")
-        );
-
-        productService.delete(product);
-
-        return new RsData<>(
-                200,
-                "%d번 상품이 삭제되었습니다.".formatted(id),
-                null
-        );
-
-
-    }
-    record OrderReqBody (boolean orderable) {}
-
-    @Operation(
-            summary = "주문 가능 불가능 설정",
-            description = "상품의 주문 가능 여부를 true 또는 false로 변경, 데이터는 orderable만 보냅니다"
-    )
-    @Transactional
-    @PutMapping("/products/{id}/orderable")
-    public RsData<ProductWithOrderable> isOrderable( @PathVariable long id,
-                                     @RequestBody OrderReqBody reqBody) {
-
-        Product product = productService.getItem(id).orElseThrow(
-                () -> new ServiceException(404,"존재하지 않는 상품입니다.")
-        );
-
-        productService.updateOrderable(product,reqBody.orderable());
-
-        String message = String.format(
-                "%d번 상품이 주문 %s하게 변경되었습니다.",
-                id,
-                reqBody.orderable() ? "가능" : "불가능"
-        );
-
-        return new RsData<>(
-                200,
-                message,
-                new ProductWithOrderable(product.isOrderable())
-        );
-
-
-    }
 
 }

--- a/src/main/java/com/back/domain/product/service/ProductService.java
+++ b/src/main/java/com/back/domain/product/service/ProductService.java
@@ -1,6 +1,6 @@
 package com.back.domain.product.service;
 
-import com.back.domain.product.controller.ProductController;
+import com.back.domain.product.controller.AdmProductController;
 import com.back.domain.product.entity.Product;
 import com.back.domain.product.repository.ProductRepository;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -60,7 +60,7 @@ public class ProductService {
     }
 
     //상품생성시
-    public Product uploadObject(ProductController.GCSReqBody reqBody, MultipartFile file) throws IOException {
+    public Product uploadObject(AdmProductController.GCSReqBody reqBody, MultipartFile file) throws IOException {
         // 1. 우선 상품을 imageUrl 없이 저장
         Product product = create(
                 reqBody.productName(),

--- a/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
+++ b/src/main/java/com/back/global/security/CustomAuthenticationFilter.java
@@ -62,7 +62,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
         String apiKey;
         String accessToken;
 
-        // API 키와 액세스 토큰을 헤더에서 가져오기
+        // API 키와 액세스 토큰을 헤더나 쿠키에서 가져오기
         String headerAuthorization = rq.getHeader("Authorization", "");
 
         if (!headerAuthorization.isBlank()) {
@@ -93,6 +93,7 @@ public class CustomAuthenticationFilter extends OncePerRequestFilter {
         Member member = null;
         boolean isAccessTokenValid = false;
 
+        // accessToken이 존재하는 경우, 해당 토큰의 유효성을 검사
         if (isAccessTokenExists){
             Map<String, Object> payload = memberService.payload(accessToken);
 

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -20,15 +20,17 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
-            .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/favicon.ico").permitAll() // 파비콘 접근 허용 (검색 엔진 최적화)
-                .requestMatchers("/h2-console/**").permitAll() // H2 콘솔 접근 허용
-                .requestMatchers("/api/members/login", "/api/members/logout").permitAll() // 로그인, 로그아웃은 인증 없이 허용
-                .requestMatchers(HttpMethod.POST, "/api/members/join").permitAll() // 회원 가입은 인증 없이 허용
-                .requestMatchers("/api/adm/**").hasRole("ADMIN") // 관리자 API는 ADMIN 권한이 있는 사용자만 접근 허용
-                .requestMatchers("/api/**").authenticated() // 나머지 API는 인증된 사용자만 접근 허용
-                .anyRequest().permitAll()
-            )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/favicon.ico").permitAll() // 파비콘 접근 허용 (검색 엔진 최적화)
+                        .requestMatchers("/h2-console/**").permitAll() // H2 콘솔 접근 허용
+                        .requestMatchers("/api/members/login", "/api/members/logout").permitAll() // 로그인, 로그아웃은 인증 없이 허용
+                        .requestMatchers(HttpMethod.POST, "/api/members/join").permitAll() // 회원 가입은 인증 없이 허용
+                        .requestMatchers("/api/adm/**").hasRole("ADMIN") // 관리자 API는 ADMIN 권한이 있는 사용자만 접근 허용
+                        .requestMatchers(HttpMethod.GET, "/api/products").permitAll()        // 상품 목록은 로그인 없어도 볼수있음
+                        .requestMatchers(HttpMethod.GET, "/api/products/{id}").permitAll()   // 상품 상세는 로그인 없어도 볼수있음
+                        .requestMatchers("/api/**").authenticated() // 나머지 API는 인증된 사용자만 접근 허용
+                        .anyRequest().permitAll()
+                )
                 .csrf(AbstractHttpConfigurer::disable) // CSRF 보호 비활성화 (API 서버에서는 일반적으로 비활성화)
                 .formLogin(AbstractHttpConfigurer::disable)
                 .logout(AbstractHttpConfigurer::disable)
@@ -37,9 +39,9 @@ public class SecurityConfig {
                 .addFilterBefore(customAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers(
                         headers -> headers
-                        .frameOptions(
-                                HeadersConfigurer.FrameOptionsConfig::sameOrigin
-                        )
+                                .frameOptions(
+                                        HeadersConfigurer.FrameOptionsConfig::sameOrigin
+                                )
                 )
                 .exceptionHandling(
                         exceptionHandling -> exceptionHandling

--- a/src/main/java/com/back/global/security/SecurityConfig.java
+++ b/src/main/java/com/back/global/security/SecurityConfig.java
@@ -23,11 +23,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/favicon.ico").permitAll() // 파비콘 접근 허용 (검색 엔진 최적화)
                         .requestMatchers("/h2-console/**").permitAll() // H2 콘솔 접근 허용
+                        .requestMatchers(HttpMethod.GET, "/api/products/**").permitAll()        // 상품 목록은 로그인 없어도 볼수있음
                         .requestMatchers("/api/members/login", "/api/members/logout").permitAll() // 로그인, 로그아웃은 인증 없이 허용
                         .requestMatchers(HttpMethod.POST, "/api/members/join").permitAll() // 회원 가입은 인증 없이 허용
                         .requestMatchers("/api/adm/**").hasRole("ADMIN") // 관리자 API는 ADMIN 권한이 있는 사용자만 접근 허용
-                        .requestMatchers(HttpMethod.GET, "/api/products").permitAll()        // 상품 목록은 로그인 없어도 볼수있음
-                        .requestMatchers(HttpMethod.GET, "/api/products/{id}").permitAll()   // 상품 상세는 로그인 없어도 볼수있음
                         .requestMatchers("/api/**").authenticated() // 나머지 API는 인증된 사용자만 접근 허용
                         .anyRequest().permitAll()
                 )

--- a/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
+++ b/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
@@ -50,7 +50,6 @@ public class AdmOrderControllerTest {
                 .andExpect(jsonPath("$.data").isArray())
                 .andExpect(jsonPath("$.data.length()").value(orders.size()));
 
-        // 4. 각 주문 데이터 검증
         for (int i = 0; i < orders.size(); i++) {
             Order order = orders.get(i);
             resultActions
@@ -69,6 +68,47 @@ public class AdmOrderControllerTest {
         ResultActions resultActions = mockMvc
                 .perform(
                         get("/api/adm/orders")
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 - 관리자")
+    @WithUserDetails("admin@gmail.com")
+    void t3() throws Exception {
+
+        List<Order> orders = orderService.getAllOrders();
+        Order targetOrder = orders.get(0);
+
+
+        ResultActions resultActions = mockMvc
+                .perform(get("/api/adm/orders/" + targetOrder.getId() + "/detail"))
+                .andDo(print());
+
+
+        resultActions
+                .andExpect(handler().handlerType(AdmOrderController.class))
+                .andExpect(handler().methodName("getOrderDetail"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("주문 상세 조회에 성공했습니다."))
+                .andExpect(jsonPath("$.data.id").value(targetOrder.getId()))
+                .andExpect(jsonPath("$.data.customerEmail").value(targetOrder.getCustomer().getEmail()))
+                .andExpect(jsonPath("$.data.customerAddress").value(targetOrder.getCustomerAddress()))
+                .andExpect(jsonPath("$.data.state").value(targetOrder.getStatus().name()))
+                .andExpect(jsonPath("$.data.orderItems").isArray());
+    }
+
+    @Test
+    @DisplayName("주문 상세 조회 - 권한 없음")
+    @WithUserDetails("user2@gmail.com")
+    void t4() throws Exception {
+        ResultActions resultActions = mockMvc
+                .perform(
+                        get("/api/adm/orders/1/detail")
                 )
                 .andDo(print());
 

--- a/src/test/java/com/back/domain/product/controller/AdmProductControllerTest.java
+++ b/src/test/java/com/back/domain/product/controller/AdmProductControllerTest.java
@@ -1,0 +1,300 @@
+package com.back.domain.product.controller;
+
+import com.back.domain.product.entity.Product;
+import com.back.domain.product.service.ProductService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.hamcrest.Matchers.matchesPattern;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.handler;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+@Transactional
+public class AdmProductControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+    @Autowired
+    private ProductService productService;
+
+    private void checkProduct(ResultActions resultActions, Product product) throws Exception {
+        resultActions
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.id").value(product.getId()))
+                .andExpect(jsonPath("$.data.productName").value(product.getProductName()))
+                .andExpect(jsonPath("$.data.price").value(product.getPrice()))
+                .andExpect(jsonPath("$.data.imageUrl").value(product.getImageUrl()))
+                .andExpect(jsonPath("$.data.category").value(product.getCategory()))
+                .andExpect(jsonPath("$.data.description").value(product.getDescription()))
+                .andExpect(jsonPath("$.data.orderable").value(product.isOrderable()))
+                .andExpect(jsonPath("$.data.createdDate").value(matchesPattern(product.getCreatedDate().toString().replaceAll("0+$", "") + ".*")))
+                .andExpect(jsonPath("$.data.modifiedDate").value(matchesPattern(product.getModifiedDate().toString().replaceAll("0+$", "") + ".*")));
+    }
+
+
+    private void checkProducts(List<Product> products, ResultActions resultActions) throws Exception {
+
+        for (int i = 0; i < products.size(); i++) {
+
+            Product product = products.get(i);
+
+            resultActions
+                    .andExpect(jsonPath("$.data.items[%d]".formatted(i)).exists())
+                    .andExpect(jsonPath("$.data.items[%d].id".formatted(i)).value(product.getId()))
+                    .andExpect(jsonPath("$.data.items[%d].productName".formatted(i)).value(product.getProductName()))
+                    .andExpect(jsonPath("$.data.items[%d].price".formatted(i)).value(product.getPrice()))
+                    .andExpect(jsonPath("$.data.items[%d].imageUrl".formatted(i)).value(product.getImageUrl()))
+                    .andExpect(jsonPath("$.data.items[%d].category".formatted(i)).value(product.getCategory()))
+                    .andExpect(jsonPath("$.data.items[%d].description".formatted(i)).value(product.getDescription()))
+                    .andExpect(jsonPath("$.data.items[%d].orderable".formatted(i)).value(product.isOrderable()))
+                    .andExpect(jsonPath("$.data.items[%d].createdDate".formatted(i)).value(matchesPattern(product.getCreatedDate().toString().replaceAll("0+$", "") + ".*")))
+                    .andExpect(jsonPath("$.data.items[%d].modifiedDate".formatted(i)).value(matchesPattern(product.getModifiedDate().toString().replaceAll("0+$", "") + ".*")));
+        }
+
+
+    }
+
+    private ResultActions writeRequest(String productName, int price, String imageUrl,
+                                       String category, String description, boolean orderable) throws Exception {
+        String json = """
+                {
+                    "productName": "%s",
+                    "price": %d,
+                    "category": "%s",
+                    "description": "%s",
+                    "orderable": %b
+                }
+                """.formatted(productName, price, category, description, orderable);
+
+        MockMultipartFile data = new MockMultipartFile(
+                "data", "data.json", "application/json", json.getBytes(StandardCharsets.UTF_8)
+        );
+
+        // file은 선택사항 (null 가능)
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "image.png", "image/png", "dummy-image".getBytes()
+        );
+
+
+        return mvc.
+                perform(
+                        multipart("/api/adm/products")
+                                .file(data)
+                                .file(file)
+                                .contentType(MediaType.MULTIPART_FORM_DATA)
+                ).andDo(print());
+    }
+
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @Test
+    @DisplayName("상품 생성")
+    void create1() throws Exception {
+
+        String productName = "새로운 상품이름";
+        int price = 10000;
+        String imageUrl = "123";
+        String category = "아이스";
+        String description = "아이스 아메리카노";
+        boolean orderable = true;
+
+        ResultActions resultActions = writeRequest(productName, price, imageUrl, category, description, orderable);
+
+        //상품의 제일 마지막 찾는 함수
+        Product product = productService.getLatestItem().get();
+
+        resultActions
+                .andExpect(status().isCreated())
+                .andExpect(handler().handlerType(AdmProductController.class))
+                .andExpect(handler().methodName("createWithImage"))
+                .andExpect(jsonPath("$.code").value(201))
+                .andExpect(jsonPath("$.message").value("%d번 상품이 생성되었습니다.".formatted(product.getId())));
+
+        checkProduct(resultActions, product);
+
+    }
+
+    private ResultActions modifyRequest(long productId,
+                                        String productName,
+                                        int price,
+                                        String category,
+                                        String description,
+                                        boolean orderable,
+                                        MockMultipartFile imageFile) throws Exception {
+        // JSON 문자열 생성
+        String jsonData = """
+        {
+            "productName": "%s",
+            "price": %d,
+            "category": "%s",
+            "description": "%s",
+            "orderable": %b
+        }
+        """.formatted(productName, price, category, description, orderable);
+
+        // JSON을 data 파트로 넣음
+        MockMultipartFile dataPart = new MockMultipartFile(
+                "data", "data.json", "application/json", jsonData.getBytes(StandardCharsets.UTF_8)
+        );
+
+        // file 파트는 이미지를 넣거나 null 가능
+        return mvc.perform(multipart("/api/adm/products/%d".formatted(productId))
+                        .file(dataPart)
+                        .file(imageFile) // imageFile 이름은 반드시 "file"이어야 함
+                        .with(request -> {
+                            request.setMethod("PUT"); // PUT으로 강제
+                            return request;
+                        })
+                        .contentType(MediaType.MULTIPART_FORM_DATA)
+                )
+                .andDo(print());
+    }
+
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @Test
+    @DisplayName("상품 수정")
+    void modify1() throws Exception {
+
+        long productId = 1;
+        String productName = "수정된 이름";
+        int price = 1000;
+        String category = "수정된 카테고리";
+        String description = "수정된 설명";
+        boolean orderable = true;
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "file", "new-image.jpg", "image/jpeg", "image-data-here".getBytes()
+        );
+
+        ResultActions resultActions = modifyRequest(productId, productName, price,
+                category, description, orderable, imageFile);
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(AdmProductController.class))
+                .andExpect(handler().methodName("modifywithImage"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("%d번 상품이 수정되었습니다.".formatted(productId)));
+
+        Product product = productService.getItem(productId).get();
+        checkProduct(resultActions, product);
+
+    }
+
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @Test
+    @DisplayName("상품 수정2 (값 안넣을때)")
+    void modify2() throws Exception {
+
+        long productId = 1;
+        String productName = "";
+        int price = 100;
+        String category = "";
+        String description = "";
+        boolean orderable = true;
+
+        MockMultipartFile imageFile = new MockMultipartFile(
+                "file", "new-image.jpg", "image/jpeg", "image-data-here".getBytes()
+        );
+
+        ResultActions resultActions = modifyRequest(productId, productName, price,
+                category, description, orderable,imageFile);
+
+        resultActions
+                .andExpect(status().isBadRequest())
+                .andExpect(handler().handlerType(AdmProductController.class))
+                .andExpect(handler().methodName("modifywithImage"))
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("""
+                        category-NotBlank-must not be blank
+                        description-NotBlank-must not be blank
+                        productName-NotBlank-must not be blank
+                        """.trim().stripIndent())); //ServiceException에서 필드명을 알파벳 순으로 정렬함, 필드명-코드-메세지 형태
+
+    }
+
+    private ResultActions deleteRequest(long productId) throws Exception {
+        return mvc
+                .perform(
+                        delete("/api/adm/products/%d".formatted(productId))
+                )
+                .andDo(print());
+    }
+
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @Test
+    @DisplayName("상품 삭제")
+    void delete1() throws Exception {
+
+        long productId = 1;
+
+        ResultActions resultActions = deleteRequest(productId);
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(AdmProductController.class))
+                .andExpect(handler().methodName("delete"))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("%d번 상품이 삭제되었습니다.".formatted(productId)));
+
+    }
+
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @Test
+    @DisplayName("상품 삭제 - (존재하지 않는)")
+    void delete2() throws Exception {
+        long nonExistentProductId = 99999;
+
+        ResultActions resultActions = deleteRequest(nonExistentProductId);
+
+        resultActions
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(404))
+                .andExpect(jsonPath("$.message").value("존재하지 않는 상품입니다."));
+    }
+
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    @Test
+    @DisplayName("주문 가능 불가능")
+    void order1() throws Exception {
+        long productId = 1;
+
+        ResultActions resultActions = mvc
+                .perform(
+                        put("/api/adm/products/%d/orderable".formatted(productId))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "orderable" : false
+                                        }
+                                        """)
+
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(status().isOk())
+                .andExpect(handler().handlerType(AdmProductController.class))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(handler().methodName("isOrderable"))
+                .andExpect(jsonPath("$.message").value("%d번 상품이 주문 불가능하게 변경되었습니다.".formatted(productId)));
+    }
+
+}

--- a/src/test/java/com/back/domain/product/controller/ProductControllerTest.java
+++ b/src/test/java/com/back/domain/product/controller/ProductControllerTest.java
@@ -8,18 +8,15 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
-import org.springframework.http.MediaType;
-import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.hamcrest.Matchers.matchesPattern;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -78,7 +75,7 @@ public class ProductControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(
-                        get("/products")
+                        get("/api/products")
                 )
                 .andDo(print());
 
@@ -108,7 +105,7 @@ public class ProductControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(
-                        get("/products?page=%d&pageSize=%d".formatted(page, pageSize))
+                        get("/api/products?page=%d&pageSize=%d".formatted(page, pageSize))
                 )
                 .andDo(print());
 
@@ -135,10 +132,10 @@ public class ProductControllerTest {
     void items3() throws Exception {
         // 잘못된 page, pageSize 조합들
         String[] invalidRequests = {
-                "/products?page=0&pageSize=5",     // page < 1
-                "/products?page=-1&pageSize=5",    // page 음수
-                "/products?page=1&pageSize=0",     // pageSize < 1
-                "/products?page=1&pageSize=101"    // pageSize > 100
+                "/api/products?page=0&pageSize=5",     // page < 1
+                "/api/products?page=-1&pageSize=5",    // page 음수
+                "/api/products?page=1&pageSize=0",     // pageSize < 1
+                "/api/products?page=1&pageSize=101"    // pageSize > 100
         };
 
         for (String url : invalidRequests) {
@@ -162,7 +159,7 @@ public class ProductControllerTest {
 
         ResultActions resultActions = mvc
                 .perform(
-                        get("/products/%d".formatted(productId))
+                        get("/api/products/%d".formatted(productId))
                 )
                 .andDo(print());
 
@@ -178,226 +175,4 @@ public class ProductControllerTest {
         checkProduct(resultActions, product);
 
     }
-
-
-    private ResultActions writeRequest(String productName, int price, String imageUrl,
-                                       String category, String description, boolean orderable) throws Exception {
-        String json = """
-                {
-                    "productName": "%s",
-                    "price": %d,
-                    "category": "%s",
-                    "description": "%s",
-                    "orderable": %b
-                }
-                """.formatted(productName, price, category, description, orderable);
-
-        MockMultipartFile data = new MockMultipartFile(
-                "data", "data.json", "application/json", json.getBytes(StandardCharsets.UTF_8)
-        );
-
-        // file은 선택사항 (null 가능)
-        MockMultipartFile file = new MockMultipartFile(
-                "file", "image.png", "image/png", "dummy-image".getBytes()
-        );
-
-
-        return mvc.
-                perform(
-                        multipart("/products")
-                                .file(data)
-                                .file(file)
-                                .contentType(MediaType.MULTIPART_FORM_DATA)
-                ).andDo(print());
-    }
-
-    @Test
-    @DisplayName("상품 생성")
-    void create1() throws Exception {
-
-        String productName = "새로운 상품이름";
-        int price = 10000;
-        String imageUrl = "123";
-        String category = "아이스";
-        String description = "아이스 아메리카노";
-        boolean orderable = true;
-
-        ResultActions resultActions = writeRequest(productName, price, imageUrl, category, description, orderable);
-
-        //상품의 제일 마지막 찾는 함수
-        Product product = productService.getLatestItem().get();
-
-        resultActions
-                .andExpect(status().isCreated())
-                .andExpect(handler().handlerType(ProductController.class))
-                .andExpect(handler().methodName("createWithImage"))
-                .andExpect(jsonPath("$.code").value(201))
-                .andExpect(jsonPath("$.message").value("%d번 상품이 생성되었습니다.".formatted(product.getId())));
-
-        checkProduct(resultActions, product);
-
-    }
-
-    private ResultActions modifyRequest(long productId,
-                                        String productName,
-                                        int price,
-                                        String category,
-                                        String description,
-                                        boolean orderable,
-                                        MockMultipartFile imageFile) throws Exception {
-        // JSON 문자열 생성
-        String jsonData = """
-        {
-            "productName": "%s",
-            "price": %d,
-            "category": "%s",
-            "description": "%s",
-            "orderable": %b
-        }
-        """.formatted(productName, price, category, description, orderable);
-
-        // JSON을 data 파트로 넣음
-        MockMultipartFile dataPart = new MockMultipartFile(
-                "data", "data.json", "application/json", jsonData.getBytes(StandardCharsets.UTF_8)
-        );
-
-        // file 파트는 이미지를 넣거나 null 가능
-        return mvc.perform(multipart("/products/%d".formatted(productId))
-                        .file(dataPart)
-                        .file(imageFile) // imageFile 이름은 반드시 "file"이어야 함
-                        .with(request -> {
-                            request.setMethod("PUT"); // PUT으로 강제
-                            return request;
-                        })
-                        .contentType(MediaType.MULTIPART_FORM_DATA)
-                )
-                .andDo(print());
-    }
-
-    @Test
-    @DisplayName("상품 수정")
-    void modify1() throws Exception {
-
-        long productId = 1;
-        String productName = "수정된 이름";
-        int price = 1000;
-        String category = "수정된 카테고리";
-        String description = "수정된 설명";
-        boolean orderable = true;
-
-        MockMultipartFile imageFile = new MockMultipartFile(
-                "file", "new-image.jpg", "image/jpeg", "image-data-here".getBytes()
-        );
-
-        ResultActions resultActions = modifyRequest(productId, productName, price,
-                category, description, orderable, imageFile);
-
-        resultActions
-                .andExpect(status().isOk())
-                .andExpect(handler().handlerType(ProductController.class))
-                .andExpect(handler().methodName("modifywithImage"))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%d번 상품이 수정되었습니다.".formatted(productId)));
-
-        Product product = productService.getItem(productId).get();
-        checkProduct(resultActions, product);
-
-    }
-
-    @Test
-    @DisplayName("상품 수정2 (값 안넣을때)")
-    void modify2() throws Exception {
-
-        long productId = 1;
-        String productName = "";
-        int price = 100;
-        String category = "";
-        String description = "";
-        boolean orderable = true;
-
-        MockMultipartFile imageFile = new MockMultipartFile(
-                "file", "new-image.jpg", "image/jpeg", "image-data-here".getBytes()
-        );
-
-        ResultActions resultActions = modifyRequest(productId, productName, price,
-                category, description, orderable,imageFile);
-
-        resultActions
-                .andExpect(status().isBadRequest())
-                .andExpect(handler().handlerType(ProductController.class))
-                .andExpect(handler().methodName("modifywithImage"))
-                .andExpect(jsonPath("$.code").value(400))
-                .andExpect(jsonPath("$.message").value("""
-                        category-NotBlank-must not be blank
-                        description-NotBlank-must not be blank
-                        productName-NotBlank-must not be blank
-                        """.trim().stripIndent())); //ServiceException에서 필드명을 알파벳 순으로 정렬함, 필드명-코드-메세지 형태
-
-    }
-
-    private ResultActions deleteRequest(long productId) throws Exception {
-        return mvc
-                .perform(
-                        delete("/products/%d".formatted(productId))
-                )
-                .andDo(print());
-    }
-
-    @Test
-    @DisplayName("상품 삭제")
-    void delete1() throws Exception {
-
-        long productId = 1;
-
-        ResultActions resultActions = deleteRequest(productId);
-
-        resultActions
-                .andExpect(status().isOk())
-                .andExpect(handler().handlerType(ProductController.class))
-                .andExpect(handler().methodName("delete"))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%d번 상품이 삭제되었습니다.".formatted(productId)));
-
-    }
-
-    @Test
-    @DisplayName("상품 삭제 - (존재하지 않는)")
-    void delete2() throws Exception {
-        long nonExistentProductId = 99999;
-
-        ResultActions resultActions = deleteRequest(nonExistentProductId);
-
-        resultActions
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.code").value(404))
-                .andExpect(jsonPath("$.message").value("존재하지 않는 상품입니다."));
-    }
-
-    @Test
-    @DisplayName("주문 가능 불가능")
-    void order1() throws Exception {
-        long productId = 1;
-
-        ResultActions resultActions = mvc
-                .perform(
-                        put("/products/%d/orderable".formatted(productId))
-                                .contentType(MediaType.APPLICATION_JSON)
-                                .content("""
-                                        {
-                                            "orderable" : false
-                                        }
-                                        """)
-
-                )
-                .andDo(print());
-
-        resultActions
-                .andExpect(status().isOk())
-                .andExpect(handler().handlerType(ProductController.class))
-                .andExpect(jsonPath("$.code").value(200))
-                .andExpect(handler().methodName("isOrderable"))
-                .andExpect(jsonPath("$.message").value("%d번 상품이 주문 불가능하게 변경되었습니다.".formatted(productId)));
-    }
-
-
 }


### PR DESCRIPTION
## 📢 기능 설명
상품crud에 대한 SecurityConfig설정, 관리자 ,사용자 컨트롤러 조직화
테스트파일 재설정


필요시 실행결과 스크린샷 첨부
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
close #75
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 관리자 전용 상품 관리 기능(생성, 수정, 삭제, 주문 가능 상태 변경) 및 주문 상세 조회 기능이 추가되었습니다.
* **변경 사항**
  * 상품 및 주문 상세 조회, 관리 관련 엔드포인트가 일반 사용자 컨트롤러에서 관리자 컨트롤러로 이동되었습니다.
  * 상품 목록 및 상세 조회 API는 로그인 없이 접근할 수 있도록 변경되었습니다.
  * JWT 토큰에서 isAdmin 정보를 추출하여 반환하도록 개선되었습니다.
* **버그 수정**
  * 없음
* **테스트**
  * 관리자 상품/주문 관리 기능에 대한 통합 테스트 및 권한 테스트가 추가되었습니다.
  * 일반 사용자 상품 컨트롤러 테스트는 조회 관련 테스트만 남기고 정리되었습니다.
* **문서**
  * Swagger/OpenAPI 문서가 관리자 상품 관리 엔드포인트에 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->