### PR TITLE
[feat] 주문 처리 상태 변경(관리자 권한)

### DIFF
--- a/src/main/java/com/back/domain/order/controller/AdmOrderController.java
+++ b/src/main/java/com/back/domain/order/controller/AdmOrderController.java
@@ -8,12 +8,10 @@ import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -51,6 +49,28 @@ public class AdmOrderController {
                 new OrderDtoWithSpecific(order));
     }
 
-    // 주문 처리 상태 변경 (취소 포함)
+    record OrderStatusReqBody(
+            @NotNull String status
+    ) {}
+
+    record OrderStatusResBody(
+            Long id,
+            String status
+    ) {}
+
+    // 주문 처리 상태 변경 (주문완료, 배송중, 배송완료, 주문취소)
+    @PutMapping("/{orderId}/status")
+    @Operation(summary = "주문 상태 변경", description = "주문 상태를 변경합니다. 예: ORDERED, SHIPPING, COMPLETED, CANCELED")
+    public RsData<OrderStatusResBody> updateOrderStatus(@PathVariable Long orderId,@RequestBody OrderStatusReqBody reqBody) {
+        Order order = orderService.updateOrderStatus(orderId, reqBody.status());
+        return new RsData<>(
+                200,
+                "%s번 주문의 상태가 %s로 변경되었습니다.".formatted(orderId, reqBody.status()),
+                new OrderStatusResBody(
+                        order.getId(),
+                        order.getStatus().getDescription()
+                )
+        );
+    }
 
 }

--- a/src/main/java/com/back/domain/order/controller/AdmOrderController.java
+++ b/src/main/java/com/back/domain/order/controller/AdmOrderController.java
@@ -8,6 +8,7 @@ import com.back.global.rsData.RsData;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -61,11 +62,13 @@ public class AdmOrderController {
     // 주문 처리 상태 변경 (주문완료, 배송중, 배송완료, 주문취소)
     @PutMapping("/{orderId}/status")
     @Operation(summary = "주문 상태 변경", description = "주문 상태를 변경합니다. 예: ORDERED, SHIPPING, COMPLETED, CANCELED")
-    public RsData<OrderStatusResBody> updateOrderStatus(@PathVariable Long orderId,@RequestBody OrderStatusReqBody reqBody) {
+    public RsData<OrderStatusResBody> updateOrderStatus(
+            @PathVariable Long orderId,
+            @Valid @RequestBody OrderStatusReqBody reqBody) {
         Order order = orderService.updateOrderStatus(orderId, reqBody.status());
         return new RsData<>(
                 200,
-                "%s번 주문의 상태가 %s로 변경되었습니다.".formatted(orderId, reqBody.status()),
+                "%s번 주문의 상태가 %s로 변경되었습니다.".formatted(orderId, order.getStatus().getDescription()),
                 new OrderStatusResBody(
                         order.getId(),
                         order.getStatus().getDescription()

--- a/src/main/java/com/back/domain/order/controller/AdmOrderController.java
+++ b/src/main/java/com/back/domain/order/controller/AdmOrderController.java
@@ -51,4 +51,6 @@ public class AdmOrderController {
                 new OrderDtoWithSpecific(order));
     }
 
+    // 주문 처리 상태 변경 (취소 포함)
+
 }

--- a/src/main/java/com/back/domain/order/entity/OrderStatus.java
+++ b/src/main/java/com/back/domain/order/entity/OrderStatus.java
@@ -2,7 +2,6 @@ package com.back.domain.order.entity;
 
 public enum OrderStatus {
     ORDERED("주문완료"),
-    PAID("결제완료"),
     SHIPPING("배송중"),
     COMPLETED("배송완료"),
     CANCELED("주문취소");

--- a/src/main/java/com/back/domain/order/service/OrderService.java
+++ b/src/main/java/com/back/domain/order/service/OrderService.java
@@ -58,17 +58,16 @@ public class OrderService {
                 .orElseThrow(() -> new ServiceException(404, "해당 주문이 존재하지 않습니다."));
 
         Member customer = order.getCustomer();
-        if (customer == null) {
+        if (customer == null)
             throw new ServiceException(400, "주문에 고객 정보가 없습니다.");
-        }
-        else if (!customer.getId().equals(actor.getId())) {
+
+        // 주문 취소 권한 체크 : 주문한 고객이거나, 관리자일 때만 취소 가능
+        else if (!customer.getId().equals(actor.getId()) && !actor.isAdmin())
             throw new ServiceException(403, "%d번 주문 취소 권한이 없습니다.".formatted(order.getId()));
 
-        }
-
-        if (order.isCanceled()) {
+        if (order.isCanceled())
             throw new ServiceException(409, "이미 취소된 주문입니다.");
-        }
+
 
         order.changeStatus(OrderStatus.CANCELED);
         return order;
@@ -79,13 +78,11 @@ public class OrderService {
         Order order = orderRepository.findById(orderId)
                 .orElseThrow(() -> new ServiceException(404, "해당 주문이 존재하지 않습니다."));
 
-        if (!order.getCustomer().getId().equals(actor.getId())) {
+        if (!order.getCustomer().getId().equals(actor.getId()))
             throw new ServiceException(403, "%d번 주문 주소 변경 권한이 없습니다.".formatted(order.getId()));
-        }
 
-        if (order.isCanceled()) {
+        if (order.isCanceled())
             throw new ServiceException(409, "이미 취소된 주문입니다.");
-        }
 
         order.changeCustomerAddress(newAddress);
         orderRepository.save(order);

--- a/src/main/java/com/back/domain/order/service/OrderService.java
+++ b/src/main/java/com/back/domain/order/service/OrderService.java
@@ -9,6 +9,7 @@ import com.back.domain.order.repository.OrderRepository;
 import com.back.domain.product.entity.Product;
 import com.back.domain.product.repository.ProductRepository;
 import com.back.global.exception.ServiceException;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -91,5 +92,20 @@ public class OrderService {
 
     public Optional<Order> findLatest() {
         return orderRepository.findFirstByOrderByIdDesc();
+    }
+
+    public Order updateOrderStatus(Long orderId, @NotNull String status) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new ServiceException(404, "해당 주문이 존재하지 않습니다."));
+
+        OrderStatus orderStatus;
+        try {
+            orderStatus = OrderStatus.valueOf(status);
+        } catch (IllegalArgumentException e) {
+            throw new ServiceException(400, "유효하지 않은 주문 상태입니다.");
+        }
+
+        order.changeStatus(orderStatus);
+        return orderRepository.save(order);
     }
 }

--- a/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
+++ b/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
@@ -39,7 +39,7 @@ public class AdmOrderControllerTest {
     @Autowired
     private OrderService orderService;
     @Autowired
-    private MemberService userService;
+    private MemberService memberService;
 
     @Test
     @DisplayName("주문 목록 조회 - 관리자")
@@ -131,7 +131,7 @@ public class AdmOrderControllerTest {
     @WithUserDetails("admin@gmail.com")
     void t5() throws Exception {
         // given : 주문 상태를 변경할 주문을 준비
-        Member user = userService.findByEmail("user1@gmail.com")
+        Member user = memberService.findByEmail("user1@gmail.com")
                 .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
         Order targetOrder = orderService.createOrder(
                 user,
@@ -173,7 +173,7 @@ public class AdmOrderControllerTest {
     @WithUserDetails("admin@gmail.com")
     void t6() throws Exception {
         // given : 주문 상태를 변경할 주문을 준비
-        Member user = userService.findByEmail("user1@gmail.com")
+        Member user = memberService.findByEmail("user1@gmail.com")
                 .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
         Order targetOrder = orderService.createOrder(
                 user,
@@ -214,7 +214,7 @@ public class AdmOrderControllerTest {
     @WithUserDetails("admin@gmail.com")
     void t7() throws Exception {
         // given : 주문 상태를 변경할 주문을 준비
-        Member user = userService.findByEmail("user1@gmail.com")
+        Member user = memberService.findByEmail("user1@gmail.com")
                 .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
         Order targetOrder = orderService.createOrder(
                 user,
@@ -255,7 +255,7 @@ public class AdmOrderControllerTest {
     @WithUserDetails("admin@gmail.com")
     void t8() throws Exception {
         // given : 주문 상태를 변경할 주문을 준비
-        Member user = userService.findByEmail("user1@gmail.com")
+        Member user = memberService.findByEmail("user1@gmail.com")
                 .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
         Order targetOrder = orderService.createOrder(
                 user,
@@ -296,7 +296,7 @@ public class AdmOrderControllerTest {
     @WithUserDetails("admin@gmail.com")
     void t9() throws Exception {
         // given : 주문 상태를 변경할 주문을 준비
-        Member user = userService.findByEmail("user1@gmail.com")
+        Member user = memberService.findByEmail("user1@gmail.com")
                 .orElseThrow(() -> new ServiceException(404, "회원이 존재하지 않습니다."));
         Order targetOrder = orderService.createOrder(
                 user,

--- a/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
+++ b/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
@@ -157,12 +157,12 @@ public class AdmOrderControllerTest {
         // then : 응답 검증
         resultActions
                 .andExpect(handler().handlerType(AdmOrderController.class))
-                .andExpect(handler().methodName("updateOrderState"))
+                .andExpect(handler().methodName("updateOrderStatus"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("주문 상태가 변경되었습니다."))
+                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), targetOrder.getStatus())))
                 .andExpect(jsonPath("$.data.id").value(targetOrder.getId()))
-                .andExpect(jsonPath("$.data.status").value("ORDERED"));
+                .andExpect(jsonPath("$.data.status").value("주문완료"));
 
         // 추가 검증: 주문 상태가 실제로 변경되었는지 확인
         assertThat(targetOrder.getStatus()).isEqualTo(OrderStatus.ORDERED);
@@ -198,12 +198,12 @@ public class AdmOrderControllerTest {
         // then : 응답 검증
         resultActions
                 .andExpect(handler().handlerType(AdmOrderController.class))
-                .andExpect(handler().methodName("updateOrderState"))
+                .andExpect(handler().methodName("updateOrderStatus"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("주문 상태가 변경되었습니다."))
+                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), targetOrder.getStatus())))
                 .andExpect(jsonPath("$.data.id").value(targetOrder.getId()))
-                .andExpect(jsonPath("$.data.status").value("SHIPPING"));
+                .andExpect(jsonPath("$.data.status").value("배송중"));
 
         // 추가 검증: 주문 상태가 실제로 변경되었는지 확인
         assertThat(targetOrder.getStatus()).isEqualTo(OrderStatus.SHIPPING);
@@ -239,12 +239,12 @@ public class AdmOrderControllerTest {
         // then : 응답 검증
         resultActions
                 .andExpect(handler().handlerType(AdmOrderController.class))
-                .andExpect(handler().methodName("updateOrderState"))
+                .andExpect(handler().methodName("updateOrderStatus"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("주문 상태가 변경되었습니다."))
+                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), targetOrder.getStatus())))
                 .andExpect(jsonPath("$.data.id").value(targetOrder.getId()))
-                .andExpect(jsonPath("$.data.status").value("COMPLETED"));
+                .andExpect(jsonPath("$.data.status").value("배송완료"));
 
         // 추가 검증: 주문 상태가 실제로 변경되었는지 확인
         assertThat(targetOrder.getStatus()).isEqualTo(OrderStatus.COMPLETED);
@@ -280,12 +280,12 @@ public class AdmOrderControllerTest {
         // then : 응답 검증
         resultActions
                 .andExpect(handler().handlerType(AdmOrderController.class))
-                .andExpect(handler().methodName("updateOrderState"))
+                .andExpect(handler().methodName("updateOrderStatus"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("주문 상태가 변경되었습니다."))
+                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), targetOrder.getStatus())))
                 .andExpect(jsonPath("$.data.id").value(targetOrder.getId()))
-                .andExpect(jsonPath("$.data.status").value("CANCELED"));
+                .andExpect(jsonPath("$.data.status").value("주문취소"));
 
         // 추가 검증: 주문 상태가 실제로 변경되었는지 확인
         assertThat(targetOrder.getStatus()).isEqualTo(OrderStatus.CANCELED);
@@ -322,7 +322,7 @@ public class AdmOrderControllerTest {
         resultActions
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code").value(400))
-                .andExpect(jsonPath("$.message").value("잘못된 주문 상태입니다."))
+                .andExpect(jsonPath("$.message").value("유효하지 않은 주문 상태입니다."))
                 .andExpect(jsonPath("$.data").doesNotExist());
     }
 }

--- a/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
+++ b/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
@@ -160,7 +160,7 @@ public class AdmOrderControllerTest {
                 .andExpect(handler().methodName("updateOrderStatus"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), targetOrder.getStatus())))
+                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), "주문완료")))
                 .andExpect(jsonPath("$.data.id").value(targetOrder.getId()))
                 .andExpect(jsonPath("$.data.status").value("주문완료"));
 
@@ -201,7 +201,7 @@ public class AdmOrderControllerTest {
                 .andExpect(handler().methodName("updateOrderStatus"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), targetOrder.getStatus())))
+                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), "배송중")))
                 .andExpect(jsonPath("$.data.id").value(targetOrder.getId()))
                 .andExpect(jsonPath("$.data.status").value("배송중"));
 
@@ -242,7 +242,7 @@ public class AdmOrderControllerTest {
                 .andExpect(handler().methodName("updateOrderStatus"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), targetOrder.getStatus())))
+                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), "배송완료")))
                 .andExpect(jsonPath("$.data.id").value(targetOrder.getId()))
                 .andExpect(jsonPath("$.data.status").value("배송완료"));
 
@@ -283,7 +283,7 @@ public class AdmOrderControllerTest {
                 .andExpect(handler().methodName("updateOrderStatus"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), targetOrder.getStatus())))
+                .andExpect(jsonPath("$.message").value("%s번 주문의 상태가 %s로 변경되었습니다.".formatted(targetOrder.getId(), "주문취소")))
                 .andExpect(jsonPath("$.data.id").value(targetOrder.getId()))
                 .andExpect(jsonPath("$.data.status").value("주문취소"));
 


### PR DESCRIPTION
## 📢 기능 설명
- 관리자 권한으로 주문 처리 상태 변경하는 로직 작성
- 주문완료, 배송중, 배송완료, 주문취소의 4 state 구조
- 주문 취소 로직도 함께 처리함
- 관련 테스트 케이스 작성
<br>

## 연결된 issue
close #34 
close #35
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 관리자가 주문 상태를 업데이트할 수 있는 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 주문 상태 변경 시 유효하지 않은 상태 입력에 대한 오류 응답이 개선되었습니다.
  * 주문 취소 권한 체크가 고객 또는 관리자 모두 허용하도록 수정되었습니다.

* **테스트**
  * 주문 상태 변경 관련 다양한 시나리오에 대한 테스트가 추가되었습니다.  
  * 잘못된 상태 입력 시 오류가 반환되는지 확인하는 테스트가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->