### PR TITLE
[feat] 비밀번호 검증 엔드포인트 추가 #1

### DIFF
--- a/src/main/java/com/back/domain/member/member/controller/MemberController.java
+++ b/src/main/java/com/back/domain/member/member/controller/MemberController.java
@@ -213,7 +213,28 @@ public class MemberController {
         );
     }
 
+    record MemberPasswordVerifyReqBody(
+            @NotBlank
+            @Size(min = 2, max = 20)
+            String password
+    ) { }
 
+    @PostMapping("/verify-password")
+    @Operation(summary = "회원 비밀번호 검증")
+    public RsData<Void> verifyPassword(
+            @Valid @RequestBody MemberPasswordVerifyReqBody reqBody
+    ) {
+        Member actor = rq.getActor();
+        Member member = memberService.findById(actor.getId())
+                .orElseThrow(() -> new ServiceException(404, "존재하지 않는 회원입니다."));
 
+        memberService.checkPassword(member, reqBody.password());
 
+        return new RsData<>(
+                200,
+                "비밀번호가 검증됐습니다.",
+                null
+        );
+
+    }
 }

--- a/src/main/java/com/back/global/initData/DevInitData.java
+++ b/src/main/java/com/back/global/initData/DevInitData.java
@@ -37,19 +37,19 @@ public class DevInitData {
     @Transactional
     public void work1() {
         if (memberService.count() > 0) return;
-        Member memberSystem = memberService.joinAdmin("system@gmail.com", "1234", "시스템");
+        Member memberSystem = memberService.joinAdmin("system@gmail.com", "12345678", "시스템");
         memberSystem.modifyApiKey(memberSystem.getEmail());
 
-        Member memberAdmin = memberService.joinAdmin("admin@gmail.com", "1234", "관리자");
+        Member memberAdmin = memberService.joinAdmin("admin@gmail.com", "12345678", "관리자");
         memberAdmin.modifyApiKey(memberAdmin.getEmail());
 
-        Member user1 = memberService.join("user1@gmail.com", "1234", "유저1");
+        Member user1 = memberService.join("user1@gmail.com", "12345678", "유저1");
         user1.modifyApiKey(user1.getEmail());
 
-        Member user2 = memberService.join("user2@gmail.com", "1234", "유저2");
+        Member user2 = memberService.join("user2@gmail.com", "12345678", "유저2");
         user2.modifyApiKey(user2.getEmail());
 
-        Member user3 = memberService.join("user3@gmail.com", "1234", "유저3");
+        Member user3 = memberService.join("user3@gmail.com", "12345678", "유저3");
         user3.modifyApiKey(user3.getEmail());
     }
 

--- a/src/main/java/com/back/global/initData/TestInitData.java
+++ b/src/main/java/com/back/global/initData/TestInitData.java
@@ -43,19 +43,19 @@ public class TestInitData {
     @Transactional
     public void work1() {
         if (memberService.count() > 0) return;
-        Member memberSystem = memberService.joinAdmin("system@gmail.com", "1234", "시스템");
+        Member memberSystem = memberService.joinAdmin("system@gmail.com", "12345678", "시스템");
         memberSystem.modifyApiKey(memberSystem.getEmail());
 
-        Member memberAdmin = memberService.joinAdmin("admin@gmail.com", "1234", "관리자");
+        Member memberAdmin = memberService.joinAdmin("admin@gmail.com", "12345678", "관리자");
         memberAdmin.modifyApiKey(memberAdmin.getEmail());
 
-        Member user1 = memberService.join("user1@gmail.com", "1234", "유저1");
+        Member user1 = memberService.join("user1@gmail.com", "12345678", "유저1");
         user1.modifyApiKey(user1.getEmail());
 
-        Member user2 = memberService.join("user2@gmail.com", "1234", "유저2");
+        Member user2 = memberService.join("user2@gmail.com", "12345678", "유저2");
         user2.modifyApiKey(user2.getEmail());
 
-        Member user3 = memberService.join("user3@gmail.com", "1234", "유저3");
+        Member user3 = memberService.join("user3@gmail.com", "12345678", "유저3");
         user3.modifyApiKey(user3.getEmail());
     }
 

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -538,4 +538,52 @@ class MemberControllerTest {
                 .andExpect(jsonPath("$.code").value(403))
                 .andExpect(jsonPath("$.message").value("해당 주문에 대한 권한이 없습니다."));
     }
+
+    @Test
+    @DisplayName("회원 패스워드 검증")
+    @WithUserDetails("user1@gmail.com")
+    void verifyPassword() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/members/verify-password")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "password": "1234"
+                                        }
+                                        """.stripIndent())
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("verifyPassword"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("비밀번호가 일치합니다."));
+    }
+
+    @Test
+    @DisplayName("회원 패스워드 검증 - 잘못된 비밀번호")
+    @WithUserDetails("user1@gmail.com")
+    void verifyPassword_wrong() throws Exception {
+        ResultActions resultActions = mvc
+                .perform(
+                        post("/api/members/verify-password")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("""
+                                        {
+                                            "password": "wrong_password"
+                                        }
+                                        """.stripIndent())
+                )
+                .andDo(print());
+
+        resultActions
+                .andExpect(handler().handlerType(MemberController.class))
+                .andExpect(handler().methodName("verifyPassword"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(401))
+                .andExpect(jsonPath("$.message").value("비밀번호가 일치하지 않습니다."));
+    }
 }

--- a/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
+++ b/src/test/java/com/back/domain/member/member/controller/MemberControllerTest.java
@@ -83,7 +83,7 @@ class MemberControllerTest {
                                 .content("""
                                         {
                                             "email": "system@gmail.com",
-                                            "password": "1234"
+                                            "password": "12345678"
                                         }
                                         """.stripIndent())
                 )
@@ -549,7 +549,7 @@ class MemberControllerTest {
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .content("""
                                         {
-                                            "password": "1234"
+                                            "password": "12345678"
                                         }
                                         """.stripIndent())
                 )
@@ -560,7 +560,7 @@ class MemberControllerTest {
                 .andExpect(handler().methodName("verifyPassword"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
-                .andExpect(jsonPath("$.message").value("비밀번호가 일치합니다."));
+                .andExpect(jsonPath("$.message").value("비밀번호가 검증됐습니다."));
     }
 
     @Test


### PR DESCRIPTION
## 📢 기능 설명
- 유저 패스워드 검증 엔드포인트 생성
- 관련 테스트케이스 작성
- initData의 유저 패스워드를 validation에 맞게 4글자 -> 8글자로 변경
<br>

## 연결된 issue
close #117 
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 회원 비밀번호 검증을 위한 API 엔드포인트(POST /api/members/verify-password)가 추가되었습니다.

* **버그 수정**
  * 개발 및 테스트 환경의 기본 회원 비밀번호가 "1234"에서 "12345678"로 변경되었습니다.

* **테스트**
  * 비밀번호 검증 API의 정상 동작 및 실패 케이스에 대한 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->