### PR TITLE
[refactor] 주문 전체 목록 조회(관리자 권한) 엔드포인트 수정

### DIFF
--- a/src/main/java/com/back/domain/order/dto/OrderDtoWithName.java
+++ b/src/main/java/com/back/domain/order/dto/OrderDtoWithName.java
@@ -37,7 +37,9 @@ public record OrderDtoWithName(
                 order.getCreatedDate(),
                 order.getStatus(),
                 order.getCustomerAddress(),
-                null
+                order.getOrderItems().stream()
+                        .map(OrderItemDto::new)
+                        .toList()
         );
     }
 

--- a/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
+++ b/src/test/java/com/back/domain/order/controller/AdmOrderControllerTest.java
@@ -68,7 +68,9 @@ public class AdmOrderControllerTest {
                     .andExpect(jsonPath("$.data[0].createdDate").value(Matchers.startsWith(order.getCreatedDate().format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")))))
                     .andExpect(jsonPath("$.data[%d].customerName".formatted(i)).value(order.getCustomer().getName()))
                     .andExpect(jsonPath("$.data[%d].state".formatted(i)).value(order.getStatus().name()))
-                    .andExpect(jsonPath("$.data[%d].customerAddress".formatted(i)).value(order.getCustomerAddress()));
+                    .andExpect(jsonPath("$.data[%d].customerAddress".formatted(i)).value(order.getCustomerAddress()))
+                    .andExpect(jsonPath("$.data[%d].orderItems", i).isArray())
+                    .andExpect(jsonPath("$.data[%d].orderItems.length()".formatted(i)).value(order.getOrderItems().size()));
         }
     }
 


### PR DESCRIPTION
## 📢 기능 설명
- 주문 전체 목록 조회(관리자 권한)에서 각 아이템 정보도 반환하도록 변경
<br>

## 연결된 issue

연결된 issue를 자동으로 닫기 위해 아래 {이슈넘버}를 입력해주세요. <br>
없음
<br>
<br>

## 🩷 Approve 하기 전 확인해주세요!

- [ ] 리뷰어가 확인해줬으면 하는 사항 적어주세요.
- [ ]

<br>

## ✅ 체크리스트

- [ ] PR 제목 규칙 잘 지켰는가?
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?
- [ ] Approve 하기 전 확인 사항 체크했는가?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 주문 정보 조회 시 주문 항목 상세 정보가 누락되지 않고 포함되도록 개선되었습니다.

* **테스트**
  * 관리자 주문 목록 조회 테스트에 주문 항목 배열의 존재 및 크기 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->